### PR TITLE
Fixed inconsistent error handling by enforcing the usage of `handleApiError`

### DIFF
--- a/kraken_frontend/src/api/error.ts
+++ b/kraken_frontend/src/api/error.ts
@@ -44,31 +44,6 @@ export type ApiError = {
 };
 
 /**
- * Wraps a promise returned by the generated SDK which handles its errors and returns a {@link Result}
- */
-export async function handleError<T>(promise: Promise<T>): Promise<Result<T, ApiError>> {
-    try {
-        return Ok(await promise);
-    } catch (e) {
-        if (e instanceof ResponseError) {
-            return Err(await parseError(e.response));
-        } else if (e instanceof RequiredError) {
-            console.error(e);
-            return Err({
-                status_code: StatusCode.JsonDecodeError,
-                message: "The server's response didn't match the spec",
-            });
-        } else {
-            console.error("Unknown error occurred:", e);
-            return Err({
-                status_code: StatusCode.ArbitraryJSError,
-                message: "Unknown error occurred",
-            });
-        }
-    }
-}
-
-/**
  * Parse a response's body into an {@link ApiError}
  *
  * This function assumes but doesn't check, that the response is an error.

--- a/kraken_frontend/src/views/gobal-popup.tsx
+++ b/kraken_frontend/src/views/gobal-popup.tsx
@@ -4,6 +4,7 @@ import Invitation from "./workspace/invitation/invitation";
 import { SimpleUser, SimpleWorkspace, WsMessageOneOf1 } from "../api/generated";
 import { toast } from "react-toastify";
 import { Api, UUID } from "../api/api";
+import { handleApiError } from "../utils/helper";
 
 type Popup = WsInvitationToWorkspace;
 
@@ -39,17 +40,16 @@ export default class GlobalPopup extends React.Component<GlobalPopupProps, Globa
     }
 
     async retrieveInvitations() {
-        (await Api.invitations.all()).match(
-            (e) => {
+        await Api.invitations.all().then(
+            handleApiError((e) => {
                 const popups = this.state.popups;
                 popups.push(
                     ...e.invitations.map((i): WsInvitationToWorkspace => {
                         return { type: "invitation", invitationUuid: i.uuid, from: i.from, workspace: i.workspace };
-                    })
+                    }),
                 );
                 this.setState({ popups });
-            },
-            (err) => toast.error(err.message)
+            }),
         );
     }
 
@@ -57,7 +57,7 @@ export default class GlobalPopup extends React.Component<GlobalPopupProps, Globa
         console.log(
             this.state.popups.map((e) => {
                 return e.workspace.name;
-            })
+            }),
         );
         if (this.state.popups.length !== 0) {
             const popup = this.state.popups[0];

--- a/kraken_frontend/src/views/kraken-network.tsx
+++ b/kraken_frontend/src/views/kraken-network.tsx
@@ -106,14 +106,9 @@ export default class KrakenNetwork extends React.Component<KrakenNetworkProps, K
                                     const result = await Api.admin.leeches.genConfig(l.uuid);
 
                                     let config = "";
-                                    result.match(
-                                        ({ ca, cert, key, sni, secret }) => {
-                                            config = `KrakenSni = "${sni}"\nKrakenCa = """\n${ca}"""\nLeechCert = """\n${cert}"""\nLeechKey="""\n${key}"""\nLeechSecret="${secret}"`;
-                                        },
-                                        (err) => {
-                                            toast.error(err.message);
-                                        },
-                                    );
+                                    handleApiError(result, ({ ca, cert, key, sni, secret }) => {
+                                        config = `KrakenSni = "${sni}"\nKrakenCa = """\n${ca}"""\nLeechCert = """\n${cert}"""\nLeechKey="""\n${key}"""\nLeechSecret="${secret}"`;
+                                    });
                                     if (config.length == 0) return;
 
                                     await navigator.clipboard.writeText(config);

--- a/kraken_frontend/src/views/me.tsx
+++ b/kraken_frontend/src/views/me.tsx
@@ -65,32 +65,29 @@ export default class Me extends React.Component<MeProps, MeState> {
             toast.error("Name must not be empty");
         }
 
-        (await Api.user.apiKeys.create(this.state.apiKeyName)).match(
-            async (_) => {
+        await Api.user.apiKeys.create(this.state.apiKeyName).then(
+            handleApiError(async (_) => {
                 toast.success("Created api key");
                 this.setState({ apiKeyName: "" });
                 await this.retrieveApiKeys();
-            },
-            (err) => toast.error(err.message),
+            }),
         );
     }
 
     async retrieveApiKeys() {
-        (await Api.user.apiKeys.all()).match(
-            (keys) => {
+        await Api.user.apiKeys.all().then(
+            handleApiError((keys) => {
                 this.setState({ apiKeys: keys.keys });
-            },
-            (err) => toast.error(err.message),
+            }),
         );
     }
 
     async deleteApiKey(uuid: UUID) {
-        (await Api.user.apiKeys.delete(uuid)).match(
-            async (_) => {
+        Api.user.apiKeys.delete(uuid).then(
+            handleApiError(async (_) => {
                 toast.success("Deleted api key");
                 await this.retrieveApiKeys();
-            },
-            (err) => toast.error(err.message),
+            }),
         );
     }
 
@@ -116,16 +113,13 @@ export default class Me extends React.Component<MeProps, MeState> {
             displayName: displayName !== user.displayName ? displayName : null,
         };
 
-        (await Api.user.update(changes)).match(
-            (_) => {
+        await Api.user.update(changes).then(
+            handleApiError((_) => {
                 user.displayName = displayName;
                 user.username = username;
                 this.setState({ user });
                 toast.success("Account data updated");
-            },
-            (err) => {
-                toast.error(err.message);
-            },
+            }),
         );
     }
 

--- a/kraken_frontend/src/views/settings.tsx
+++ b/kraken_frontend/src/views/settings.tsx
@@ -6,7 +6,7 @@ import { toast } from "react-toastify";
 import { FullOauthClient, FullWordlist, SettingsFull } from "../api/generated";
 import CopyIcon from "../svg/copy";
 import CloseIcon from "../svg/close";
-import { copyToClipboard } from "../utils/helper";
+import { copyToClipboard, handleApiError } from "../utils/helper";
 import Textarea from "../components/textarea";
 
 type SettingsProps = {};
@@ -42,27 +42,22 @@ export default class Settings extends React.Component<SettingsProps, SettingsSta
     }
 
     async retrieveSettings() {
-        (await Api.admin.settings.get()).match(
-            (settings) => this.setState({ settings }),
-            (err) => toast.error(err.message)
-        );
+        await Api.admin.settings.get().then(handleApiError((settings) => this.setState({ settings })));
     }
 
     async getOAuthApps() {
-        (await Api.admin.oauthApplications.all()).match(
-            (apps) => {
+        await Api.admin.oauthApplications.all().then(
+            handleApiError((apps) => {
                 this.setState({ oauthApplications: apps.apps });
-            },
-            (err) => toast.error(err.message)
+            }),
         );
     }
 
     async updateWordlists() {
-        (await Api.admin.wordlists.all()).match(
-            (wordlists) => {
+        await Api.admin.wordlists.all().then(
+            handleApiError((wordlists) => {
                 this.setState({ wordlists: wordlists.wordlists });
-            },
-            (err) => toast.error(err.message)
+            }),
         );
     }
 
@@ -76,16 +71,13 @@ export default class Settings extends React.Component<SettingsProps, SettingsSta
             toast.error("Path of the wordlist must not be empty");
         }
 
-        (
-            await Api.admin.wordlists.create({
+        await Api.admin.wordlists
+            .create({
                 name: this.state.wordlistName,
                 path: this.state.wordlistPath,
                 description: this.state.wordlistDescription,
             })
-        ).match(
-            (_) => toast.success("Created wordlist"),
-            (err) => toast.error(err.message)
-        );
+            .then(handleApiError((_) => toast.success("Created wordlist")));
     }
 
     async saveSettings() {
@@ -95,10 +87,7 @@ export default class Settings extends React.Component<SettingsProps, SettingsSta
             return;
         }
 
-        (await Api.admin.settings.update(settings)).match(
-            (_) => toast.success("Settings updated"),
-            (err) => toast.error(err.message)
-        );
+        await Api.admin.settings.update(settings).then(handleApiError((_) => toast.success("Settings updated")));
     }
 
     async createOAuthApp() {
@@ -108,12 +97,9 @@ export default class Settings extends React.Component<SettingsProps, SettingsSta
             return;
         }
 
-        (
-            await Api.admin.oauthApplications.create({ name: newOAuthAppName, redirectUri: newOAuthAppRedirectUrl })
-        ).match(
-            (_) => toast.success("OAuth application created"),
-            (err) => toast.error(err.message)
-        );
+        await Api.admin.oauthApplications
+            .create({ name: newOAuthAppName, redirectUri: newOAuthAppRedirectUrl })
+            .then(handleApiError((_) => toast.success("OAuth application created")));
     }
 
     render() {
@@ -218,12 +204,11 @@ export default class Settings extends React.Component<SettingsProps, SettingsSta
                                     <button
                                         className={"icon-button"}
                                         onClick={async () => {
-                                            (await Api.admin.wordlists.delete(x.uuid)).match(
-                                                async () => {
+                                            await Api.admin.wordlists.delete(x.uuid).then(
+                                                handleApiError(async () => {
                                                     toast.success("Wordlist deleted");
                                                     await this.updateWordlists();
-                                                },
-                                                (err) => toast.error(err.message)
+                                                }),
                                             );
                                         }}
                                     >
@@ -291,14 +276,11 @@ export default class Settings extends React.Component<SettingsProps, SettingsSta
                                     <button
                                         className={"icon-button"}
                                         onClick={async () => {
-                                            (await Api.admin.oauthApplications.delete(x.uuid)).match(
-                                                async (_) => {
+                                            await Api.admin.oauthApplications.delete(x.uuid).then(
+                                                handleApiError(async (_) => {
                                                     toast.success(`Deleted application ${x.name}`);
                                                     await this.getOAuthApps();
-                                                },
-                                                (err) => {
-                                                    toast.error(err.message);
-                                                }
+                                                }),
                                             );
                                         }}
                                     >

--- a/kraken_frontend/src/views/workspace-overview.tsx
+++ b/kraken_frontend/src/views/workspace-overview.tsx
@@ -60,8 +60,8 @@ export default class WorkspaceOverview extends React.Component<WorkspacesProps, 
             handleApiError(({ workspaces }) =>
                 this.setState({
                     workspaces,
-                })
-            )
+                }),
+            ),
         );
     }
 
@@ -69,15 +69,12 @@ export default class WorkspaceOverview extends React.Component<WorkspacesProps, 
         const { newName, newDesc } = this.state;
         if (!check([[newName.length > 0, "Empty name"]])) return;
 
-        (await Api.workspaces.create({ name: newName, description: newDesc.length > 0 ? newDesc : null })).match(
-            (_) => {
+        await Api.workspaces.create({ name: newName, description: newDesc.length > 0 ? newDesc : null }).then(
+            handleApiError((_) => {
                 toast.success("Created new workspace");
                 this.setState({ newName: "", newDesc: "", createNew: false });
                 this.fetchState();
-            },
-            (err) => {
-                toast.error(err.message);
-            }
+            }),
         );
     }
 

--- a/kraken_frontend/src/views/workspace/attacks/workspace-attacks-bsd.tsx
+++ b/kraken_frontend/src/views/workspace/attacks/workspace-attacks-bsd.tsx
@@ -9,6 +9,7 @@ import "../../../styling/workspace-attacks-bsd.css";
 import SelectMenu from "../../../components/select-menu";
 import { WORKSPACE_CONTEXT } from "../workspace";
 import { PrefilledAttackParams } from "../workspace-attacks";
+import { handleApiError } from "../../../utils/helper";
 
 type WorkspaceAttacksBruteforceSubdomainsProps = { prefilled: PrefilledAttackParams };
 type WorkspaceAttacksBruteforceSubdomainsState = {
@@ -52,15 +53,14 @@ export default class WorkspaceAttacksBruteforceSubdomains extends React.Componen
     }
 
     async retrieveWordlists() {
-        (await Api.wordlists.all()).match(
-            (wordlists) => {
+        await Api.wordlists.all().then(
+            handleApiError((wordlists) =>
                 this.setState({
                     wordlists: wordlists.wordlists.map((x) => {
                         return { label: x.name, value: x.uuid };
                     }),
-                });
-            },
-            (err) => toast.error(err.message),
+                }),
+            ),
         );
     }
 
@@ -75,17 +75,14 @@ export default class WorkspaceAttacksBruteforceSubdomains extends React.Componen
             return;
         }
 
-        (
-            await Api.attacks.bruteforceSubdomains({
+        await Api.attacks
+            .bruteforceSubdomains({
                 workspaceUuid: this.context.workspace.uuid,
                 domain: this.state.domain,
                 concurrentLimit: this.state.taskLimit,
                 wordlistUuid: this.state.wordlist.value,
             })
-        ).match(
-            (_) => toast.success("Attack started"),
-            (err) => toast.error(err.message),
-        );
+            .then(handleApiError((_) => toast.success("Attack started")));
     }
 
     render() {

--- a/kraken_frontend/src/views/workspace/attacks/workspace-attacks-certificate-transparency.tsx
+++ b/kraken_frontend/src/views/workspace/attacks/workspace-attacks-certificate-transparency.tsx
@@ -9,6 +9,7 @@ import ExpandIcon from "../../../svg/expand";
 import { toast } from "react-toastify";
 import { WORKSPACE_CONTEXT } from "../workspace";
 import { PrefilledAttackParams } from "../workspace-attacks";
+import { handleApiError } from "../../../utils/helper";
 
 type WorkspaceAttacksCTProps = { prefilled: PrefilledAttackParams };
 type WorkspaceAttacksCTState = {
@@ -43,18 +44,15 @@ export default class WorkspaceAttacksCT extends React.Component<WorkspaceAttacks
     }
 
     async startAttack() {
-        (
-            await Api.attacks.queryCertificateTransparency({
+        await Api.attacks
+            .queryCertificateTransparency({
                 includeExpired: this.state.includeExpired,
                 workspaceUuid: this.context.workspace.uuid,
                 target: this.state.domain,
                 maxRetries: this.state.maxRetries,
                 retryInterval: this.state.retryInterval,
             })
-        ).match(
-            (ok) => toast.success("Attack started"),
-            (err) => toast.error(err.message),
-        );
+            .then(handleApiError((ok) => toast.success("Attack started")));
     }
 
     render() {

--- a/kraken_frontend/src/views/workspace/attacks/workspace-attacks-dehashed.tsx
+++ b/kraken_frontend/src/views/workspace/attacks/workspace-attacks-dehashed.tsx
@@ -9,6 +9,7 @@ import { Query } from "../../../api/generated";
 import SelectMenu from "../../../components/select-menu";
 import { WORKSPACE_CONTEXT } from "../workspace";
 import { PrefilledAttackParams, TargetType } from "../workspace-attacks";
+import { handleApiError } from "../../../utils/helper";
 
 export type DehashedQueryType =
     | "email"
@@ -116,10 +117,9 @@ export default class WorkspaceAttacksDehashed extends React.Component<
                 return;
         }
 
-        (await Api.attacks.queryDehashed(this.context.workspace.uuid, query)).match(
-            (uuid) => toast.success("Attack started"),
-            (err) => toast.error(err.message),
-        );
+        await Api.attacks
+            .queryDehashed(this.context.workspace.uuid, query)
+            .then(handleApiError((uuid) => toast.success("Attack started")));
     }
 
     render() {

--- a/kraken_frontend/src/views/workspace/attacks/workspace-attacks-host-alive.tsx
+++ b/kraken_frontend/src/views/workspace/attacks/workspace-attacks-host-alive.tsx
@@ -8,6 +8,7 @@ import CollapseIcon from "../../../svg/collapse";
 import ExpandIcon from "../../../svg/expand";
 import { WORKSPACE_CONTEXT } from "../workspace";
 import { PrefilledAttackParams } from "../workspace-attacks";
+import { handleApiError } from "../../../utils/helper";
 
 type WorkspaceAttacksHostAliveProps = { prefilled: PrefilledAttackParams };
 type WorkspaceAttacksHostAliveState = {
@@ -41,17 +42,14 @@ export default class WorkspaceAttacksHostAlive extends React.Component<
     }
 
     async startAttack() {
-        (
-            await Api.attacks.hostAlive({
+        await Api.attacks
+            .hostAlive({
                 timeout: this.state.timeout,
                 concurrentLimit: this.state.concurrentLimit,
                 targets: [this.state.target],
                 workspaceUuid: this.context.workspace.uuid,
             })
-        ).match(
-            (_) => toast.success("Attack started"),
-            (err) => toast.error(err.message),
-        );
+            .then(handleApiError((_) => toast.success("Attack started")));
     }
 
     render() {

--- a/kraken_frontend/src/views/workspace/attacks/workspace-attacks-port-scan-tcp.tsx
+++ b/kraken_frontend/src/views/workspace/attacks/workspace-attacks-port-scan-tcp.tsx
@@ -9,6 +9,7 @@ import Checkbox from "../../../components/checkbox";
 import { toast } from "react-toastify";
 import { WORKSPACE_CONTEXT } from "../workspace";
 import { PrefilledAttackParams } from "../workspace-attacks";
+import { handleApiError } from "../../../utils/helper";
 
 type WorkspaceAttacksPortScanTcpProps = { prefilled: PrefilledAttackParams };
 type WorkspaceAttacksPortScanTcpState = {
@@ -52,8 +53,8 @@ export default class WorkspaceAttacksPortScanTcp extends React.Component<
     }
 
     async startAttack() {
-        (
-            await Api.attacks.scanTcpPorts({
+        await Api.attacks
+            .scanTcpPorts({
                 ports: ["1-65535"],
                 timeout: this.state.timeout,
                 concurrentLimit: this.state.taskLimit,
@@ -63,10 +64,7 @@ export default class WorkspaceAttacksPortScanTcp extends React.Component<
                 targets: [this.state.ipAddInput],
                 retryInterval: this.state.interval,
             })
-        ).match(
-            (_) => toast.success("Attack started"),
-            (err) => toast.error(err.message),
-        );
+            .then(handleApiError((_) => toast.success("Attack started")));
     }
 
     render() {

--- a/kraken_frontend/src/views/workspace/attacks/workspace-attacks-service-detection.tsx
+++ b/kraken_frontend/src/views/workspace/attacks/workspace-attacks-service-detection.tsx
@@ -8,6 +8,7 @@ import ExpandIcon from "../../../svg/expand";
 import { toast } from "react-toastify";
 import { WORKSPACE_CONTEXT } from "../workspace";
 import { PrefilledAttackParams } from "../workspace-attacks";
+import { handleApiError } from "../../../utils/helper";
 
 type WorkspaceAttacksServiceDetectionProps = { prefilled: PrefilledAttackParams };
 type WorkspaceAttacksServiceDetectionState = {
@@ -52,17 +53,14 @@ export default class WorkspaceAttacksServiceDetection extends React.Component<
             return;
         }
 
-        (
-            await Api.attacks.serviceDetection({
+        await Api.attacks
+            .serviceDetection({
                 workspaceUuid: this.context.workspace.uuid,
                 address,
                 port: p,
                 timeout,
             })
-        ).match(
-            (_) => toast.success("Attack started"),
-            (err) => toast.error(err.message),
-        );
+            .then(handleApiError((_) => toast.success("Attack started")));
     }
 
     render() {

--- a/kraken_frontend/src/views/workspace/invitation/invitation.tsx
+++ b/kraken_frontend/src/views/workspace/invitation/invitation.tsx
@@ -5,6 +5,7 @@ import { toast } from "react-toastify";
 import Popup from "reactjs-popup";
 import "../../../styling/invitation.css";
 import WorkspaceIcon from "../../../svg/workspace";
+import { handleApiError } from "../../../utils/helper";
 
 type InvitationProps = {
     invitationUuid: UUID;
@@ -28,21 +29,11 @@ export default class Invitation extends React.Component<InvitationProps, Invitat
     }
 
     async acceptInvitation() {
-        (await Api.invitations.accept(this.props.invitationUuid)).match(
-            () => this.props.onFinish(),
-            (err) => {
-                toast.error(err.message);
-            }
-        );
+        await Api.invitations.accept(this.props.invitationUuid).then(handleApiError(() => this.props.onFinish()));
     }
 
     async declineInvitation() {
-        (await Api.invitations.decline(this.props.invitationUuid)).match(
-            () => this.props.onFinish(),
-            (err) => {
-                toast.error(err.message);
-            }
-        );
+        await Api.invitations.decline(this.props.invitationUuid).then(handleApiError(() => this.props.onFinish()));
     }
 
     render() {

--- a/kraken_frontend/src/views/workspace/workspace-host.tsx
+++ b/kraken_frontend/src/views/workspace/workspace-host.tsx
@@ -12,6 +12,7 @@ import { WorkspaceHostDomains } from "./workspace-host/workspace-host-domains";
 import { WorkspaceHostPorts } from "./workspace-host/workspace-host-ports";
 import { WorkspaceHostServices } from "./workspace-host/workspace-host-services";
 import { WORKSPACE_CONTEXT } from "./workspace";
+import { handleApiError } from "../../utils/helper";
 
 const TABS = { domains: "Domains", ports: "Ports", services: "Services", other: "Other" };
 
@@ -55,19 +56,17 @@ export default class WorkspaceHost extends React.Component<WorkspaceProps, Works
     }
 
     async getHostList() {
-        (await Api.workspaces.hosts.all(this.context.workspace.uuid, 1000, 0)).match(
-            ({ items }) => {
+        await Api.workspaces.hosts.all(this.context.workspace.uuid, 1000, 0).then(
+            handleApiError(({ items }) => {
                 this.setState({ hostList: items.filter(({ uuid }) => uuid !== this.props.uuid) });
-            },
-            (err) => toast.error(err.message),
+            }),
         );
     }
 
     async getHost() {
-        (await Api.workspaces.hosts.get(this.context.workspace.uuid, this.props.uuid)).match(
-            (host) => this.setState({ host }),
-            (err) => toast.error(err.message),
-        );
+        await Api.workspaces.hosts
+            .get(this.context.workspace.uuid, this.props.uuid)
+            .then(handleApiError((host) => this.setState({ host })));
     }
 
     componentDidUpdate(prevProps: Readonly<WorkspaceProps>, prevState: Readonly<WorkspaceState>, snapshot?: any) {

--- a/kraken_frontend/src/views/workspace/workspace-hosts.tsx
+++ b/kraken_frontend/src/views/workspace/workspace-hosts.tsx
@@ -13,6 +13,7 @@ import ArrowLastIcon from "../../svg/arrow-last";
 import Select from "react-select";
 import { selectStyles } from "../../components/select-menu";
 import { WORKSPACE_CONTEXT } from "./workspace";
+import { handleApiError } from "../../utils/helper";
 
 type WorkspaceHostsProps = {};
 type WorkspaceHostsState = {
@@ -34,10 +35,9 @@ export default class WorkspaceHosts extends React.Component<WorkspaceHostsProps,
     }
 
     async retrieveHosts() {
-        (await Api.workspaces.hosts.all(this.context.workspace.uuid, this.state.limit, this.state.offset)).match(
-            ({ items, total }) => this.setState({ hosts: items, total }),
-            (err) => toast.error(err.message),
-        );
+        await Api.workspaces.hosts
+            .all(this.context.workspace.uuid, this.state.limit, this.state.offset)
+            .then(handleApiError(({ items, total }) => this.setState({ hosts: items, total })));
     }
 
     componentDidMount() {

--- a/kraken_frontend/src/views/workspace/workspace.tsx
+++ b/kraken_frontend/src/views/workspace/workspace.tsx
@@ -5,6 +5,7 @@ import "../../styling/workspace.css";
 import WorkspaceHeading from "./components/workspace-heading";
 import WorkspaceMenu from "./components/workspace-menu";
 import { FullWorkspace } from "../../api/generated";
+import { handleApiError } from "../../utils/helper";
 
 export type WorkspaceContext = { workspace: FullWorkspace };
 export const WORKSPACE_CONTEXT = React.createContext<WorkspaceContext>({
@@ -41,22 +42,12 @@ export default class Workspace extends React.Component<WorkspaceProps, Workspace
     }
 
     componentDidMount() {
-        Api.workspaces.get(this.props.uuid).then((res) =>
-            res.match(
-                (workspace) => this.setState({ workspace }),
-                (err) => toast.error(err.message),
-            ),
-        );
+        Api.workspaces.get(this.props.uuid).then(handleApiError((workspace) => this.setState({ workspace })));
     }
 
     componentDidUpdate(prevProps: Readonly<WorkspaceProps>, prevState: Readonly<WorkspaceState>, snapshot?: any) {
         if (prevProps.uuid !== this.props.uuid) {
-            Api.workspaces.get(this.props.uuid).then((res) =>
-                res.match(
-                    (workspace) => this.setState({ workspace }),
-                    (err) => toast.error(err.message),
-                ),
-            );
+            Api.workspaces.get(this.props.uuid).then(handleApiError((workspace) => this.setState({ workspace })));
         }
     }
 


### PR DESCRIPTION
Also moved `handleError` and made it private. Because it should never be used outside of `api.ts` but the IDE keeps recommending it.