### PR TITLE
Reworked bruteforce subdomains to make it robuster

### DIFF
--- a/kraken/src/api/handler/attacks.rs
+++ b/kraken/src/api/handler/attacks.rs
@@ -46,7 +46,7 @@ pub struct BruteforceSubdomainsRequest {
     pub wordlist_uuid: Uuid,
 
     /// The concurrent task limit
-    #[schema(example = 20)]
+    #[schema(example = 100)]
     pub(crate) concurrent_limit: u32,
 
     /// The workspace to execute the attack in

--- a/kraken_frontend/src/views/workspace/attacks/workspace-attacks-bsd.tsx
+++ b/kraken_frontend/src/views/workspace/attacks/workspace-attacks-bsd.tsx
@@ -37,7 +37,7 @@ export default class WorkspaceAttacksBruteforceSubdomains extends React.Componen
         this.state = {
             showAdvanced: false,
             domain: this.props.prefilled.domain || "",
-            taskLimit: 1000,
+            taskLimit: 100,
             wordlists: [],
             wordlist: null,
         };

--- a/leech/src/main.rs
+++ b/leech/src/main.rs
@@ -82,7 +82,7 @@ pub enum RunCommand {
         wordlist_path: PathBuf,
         /// The concurrent task limit
         #[clap(long)]
-        #[clap(default_value_t = NonZeroU32::new(50).unwrap())]
+        #[clap(default_value_t = NonZeroU32::new(100).unwrap())]
         concurrent_limit: NonZeroU32,
     },
     /// Retrieve domains through certificate transparency

--- a/leech/src/modules/bruteforce_subdomains/error.rs
+++ b/leech/src/modules/bruteforce_subdomains/error.rs
@@ -3,6 +3,9 @@
 use std::io;
 
 use thiserror::Error;
+use tokio::sync::mpsc::error::SendError;
+
+use crate::modules::bruteforce_subdomains::BruteforceSubdomainResult;
 
 /// The errors that can be thrown when brute-forcing subdomains
 #[derive(Debug, Error)]
@@ -10,4 +13,8 @@ pub enum BruteforceSubdomainError {
     /// Error while reading the wordlist
     #[error("Could not read wordlist: {0}")]
     WordlistRead(#[from] io::Error),
+
+    /// Error while sending a result
+    #[error("The result channel has been closed")]
+    ChannelClosed(#[from] SendError<BruteforceSubdomainResult>),
 }

--- a/leech/src/modules/bruteforce_subdomains/error.rs
+++ b/leech/src/modules/bruteforce_subdomains/error.rs
@@ -17,4 +17,8 @@ pub enum BruteforceSubdomainError {
     /// Error while sending a result
     #[error("The result channel has been closed")]
     ChannelClosed(#[from] SendError<BruteforceSubdomainResult>),
+
+    /// The enumeration was aborted because the dns failed to respond repeatedly
+    #[error("DNS failed repeatedly, please retry or contact your admin")]
+    RepeatedError,
 }


### PR DESCRIPTION
Changes in actual logic:
- Unrecoverable errors (i.e. channel closed) will abort the entire attack
- When a resolving a domain fails, it is retried twice. If it still fails the entire attack will be aborted

Fixes:
- Wildcard results a reported as `*.<domain>` instead of `<random>.<domain>`
- Wildcard supports multiple records for each type (for example 2 cnames)

Refactor:
- Use `tokio` constructs instead of `futures`'