### PR TITLE
Removed remaining `unwrap` and `expect`

### DIFF
--- a/kraken/src/modules/attack_results/query_certificate_transparency.rs
+++ b/kraken/src/modules/attack_results/query_certificate_transparency.rs
@@ -1,4 +1,3 @@
-use chrono::{NaiveDateTime, TimeZone, Utc};
 use rorm::db::Executor;
 use rorm::prelude::*;
 use rorm::{insert, query};
@@ -9,6 +8,7 @@ use crate::models::{
     AggregationSource, AggregationTable, Attack, CertificateTransparencyResultInsert,
     CertificateTransparencyValueNameInsert, DomainCertainty, SourceType,
 };
+use crate::modules::utc::utc_from_seconds;
 use crate::rpc::rpc_definitions::shared::CertEntry;
 
 /// Store a query certificate transparency's result and update the aggregated domains and hosts
@@ -36,16 +36,8 @@ pub async fn store_query_certificate_transparency_result(
             issuer_name: entry.issuer_name,
             serial_number: entry.serial_number,
             common_name: entry.common_name.clone(),
-            not_before: entry.not_before.clone().map(|x| {
-                Utc.from_utc_datetime(
-                    &NaiveDateTime::from_timestamp_millis(x.seconds * 1000).unwrap(),
-                )
-            }),
-            not_after: entry.not_after.clone().map(|x| {
-                Utc.from_utc_datetime(
-                    &NaiveDateTime::from_timestamp_millis(x.seconds * 1000).unwrap(),
-                )
-            }),
+            not_before: entry.not_before.map(|x| utc_from_seconds(x.seconds)),
+            not_after: entry.not_after.map(|x| utc_from_seconds(x.seconds)),
         })
         .await?;
 

--- a/kraken/src/modules/attacks/certificate_transparency.rs
+++ b/kraken/src/modules/attacks/certificate_transparency.rs
@@ -1,8 +1,7 @@
-use chrono::{NaiveDateTime, TimeZone, Utc};
-
 use crate::chan::{CertificateTransparencyEntry, LeechClient, WsMessage, GLOBAL};
 use crate::modules::attack_results::store_query_certificate_transparency_result;
 use crate::modules::attacks::{AttackContext, AttackError, CertificateTransparencyParams};
+use crate::modules::utc::utc_from_seconds;
 use crate::rpc::rpc_definitions::CertificateTransparencyRequest;
 
 impl AttackContext {
@@ -43,18 +42,8 @@ impl AttackContext {
                     issuer_name: e.issuer_name,
                     common_name: e.common_name,
                     value_names: e.value_names,
-                    not_before: e.not_before.map(|ts| {
-                        Utc.from_utc_datetime(
-                            &NaiveDateTime::from_timestamp_opt(ts.seconds, ts.nanos as u32)
-                                .unwrap(),
-                        )
-                    }),
-                    not_after: e.not_after.map(|ts| {
-                        Utc.from_utc_datetime(
-                            &NaiveDateTime::from_timestamp_opt(ts.seconds, ts.nanos as u32)
-                                .unwrap(),
-                        )
-                    }),
+                    not_before: e.not_before.map(|ts| utc_from_seconds(ts.seconds)),
+                    not_after: e.not_after.map(|ts| utc_from_seconds(ts.seconds)),
                 })
                 .collect(),
         })

--- a/kraken/src/modules/mod.rs
+++ b/kraken/src/modules/mod.rs
@@ -8,3 +8,4 @@ pub mod cache;
 pub mod oauth;
 pub mod tls;
 pub mod uri;
+mod utc;

--- a/kraken/src/modules/utc.rs
+++ b/kraken/src/modules/utc.rs
@@ -1,0 +1,21 @@
+//! Some utility functions for `DateTime<Utc>`
+
+use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+use log::warn;
+
+/// Convert a raw timestamp in seconds into a `DateTime<Utc>`
+///
+/// The out of range error by `chrono` is handled by clipping to the range.
+pub fn utc_from_seconds(seconds: i64) -> DateTime<Utc> {
+    Utc.from_utc_datetime(
+        &if let Some(time) = NaiveDateTime::from_timestamp_opt(seconds, 0) {
+            time
+        } else if seconds < 0 {
+            warn!("Timestamp is out of NaiveDateTime's range. Falling back to its minimum.");
+            NaiveDateTime::MIN
+        } else {
+            warn!("Timestamp is out of NaiveDateTime's range. Falling back to its maximum.");
+            NaiveDateTime::MAX
+        },
+    )
+}


### PR DESCRIPTION
The workspace search has been refactored quite a bit, because its original structure allowed avoidable errors and made handling `rorm::Error` quite cumbersome.