### PR TITLE
Moved WsMessage serialization to the inital `send` call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1878,6 +1878,7 @@ dependencies = [
  "argon2",
  "base64 0.21.5",
  "bytes",
+ "bytestring",
  "chrono",
  "clap",
  "dehashed-rs",

--- a/kraken/Cargo.toml
+++ b/kraken/Cargo.toml
@@ -44,6 +44,7 @@ serde_urlencoded = { version = "~0.7" } # required for oauth
 chrono = { version = ">=0.4.20", default-features = false, features = ["serde"] }
 # Bytes abstractions for network usage
 bytes = { version = "~1" }
+bytestring = { version = "~1" }
 # Base64 decoder and encoder
 base64 = { version = "~0.21" }
 # ip networks


### PR DESCRIPTION
This fixes clippy's variant size complain and avoids potentially duplicated work although it's cheap anyway.