### PR TITLE
upgrade h2 to mitigate upstream security vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,9 +1579,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -2764,6 +2764,8 @@ dependencies = [
 name = "probe-config"
 version = "0.1.0"
 dependencies = [
+ "base64 0.21.5",
+ "hex",
  "log",
  "regex",
 ]


### PR DESCRIPTION
should fix the CI failures