### PR TITLE
docs: show how to format TLS config

### DIFF
--- a/docs/docs/contribution/dev_setup.md
+++ b/docs/docs/contribution/dev_setup.md
@@ -8,7 +8,7 @@ The easiest way to get kraken running locally is using Vagrant and the provided 
 
 Copy the `example.vars.yml` to `vars.yml` in the vagrant folder and set test values for the tokens, names and passwords. A sample `vars.yml` might start like this:
 
-```yml
+```yaml
 --8<-- "example.vars.yml:sample"
   ...
 ```
@@ -79,7 +79,12 @@ https://10.13.37.11:31337
 
 When added to the list, click on "Gen tls config"
 
-The TLS config will be copied to clipboard (KrakenSni, KrakenCa, etc.). Paste this configuration inside your `vars.yml` as value for the `generated_leech_conf` field. (note that you need to indent the string to avoid YAML syntax errors)
+The TLS config will be copied to clipboard (KrakenSni, KrakenCa, etc.). Paste this configuration inside your `vars.yml` as value for the `generated_leech_conf` field. Note that the formatting must be all in the same column like this:
+
+```yaml
+...
+--8<-- "example.vars.yml:tls"
+```
 
 Now since `vars.yml` has been modified, you need to re-provision the leech VM again:
 

--- a/vagrant/example.vars.yml
+++ b/vagrant/example.vars.yml
@@ -10,6 +10,7 @@
   leech_db_user: "leech"
   leech_db_password: ""
 # --8<-- [end:sample]
+# --8<-- [start:tls]
   generated_leech_conf: |
     KrakenSni = "..."
     KrakenCa = """
@@ -28,3 +29,4 @@
     -----END PRIVATE KEY-----
     """
     LeechSecret = "..."
+# --8<-- [end:tls]


### PR DESCRIPTION
developer ran into issue because IDE added spaces that shouldn't have been there