### PR TITLE
Fixed panic in get_all_services

### DIFF
--- a/kraken/src/api/handler/services/handler.rs
+++ b/kraken/src/api/handler/services/handler.rs
@@ -188,7 +188,7 @@ pub async fn get_all_services(
                         // There is an entry with the key y.key(), as y.key() was used to construct
                         // the values in the HashMap
                         #[allow(clippy::unwrap_used)]
-                        ports.remove(y.key()).unwrap()
+                        ports.get(y.key()).unwrap().clone()
                     }),
                     workspace: *workspace.key(),
                     tags: tags.remove(&uuid).unwrap_or_default(),


### PR DESCRIPTION
The `.remove` was a logic error
because multiple services could target the same port.