### PR TITLE
Extended filter

### DIFF
--- a/docs/docs/user/filter.md
+++ b/docs/docs/user/filter.md
@@ -1,0 +1,130 @@
+# Kraken's filters
+
+Kraken uses a small custom language to filter certain views, most notably the "Data" view in a workspace.
+
+## Grammar
+
+A filter consists of any number of rules where is rule is assigns a value to a key:
+
+!!! example
+    `domain: docs.kraken-project.org`
+
+You can also assign a list of values combined using the basic logic operations:
+
+!!! example
+    `domains: docs.kraken-project.org, kraken-project.org` (`,` is a logical `OR`)
+
+    `tags: ignore & !ok` (`&` is a logical `AND` and `!` is a logical `NOT`)
+
+!!! note
+    Most keys accept both singular and plural forms and there is no semantic difference between them
+
+Some values can (or have to) be expressed in ranges, for example ports.
+
+We use `-` to construct ranges.
+
+The lower and upper bounds are both inclusive and optional.
+
+!!! example
+    The following are all semantically equivalent:
+
+    `port: 1-1000`
+    `port: -1000`
+    `port: !1001-`
+
+### Operator precedence
+
+The filter syntax doesn't support parentheses or similar concepts to modify the order in which logic operations are executed.
+
+`!` is always applied first, `&` second and `,` last.
+
+(The range operator `-` is considered as part of the value and therefore applied before the `!`.)
+
+### String escaping
+
+Strings are not required to be wrapped in `"`.
+
+However, if they are not, the mustn't contain any operator including the `:` used to separate the key from its value.
+
+### EBNF (excluding whitespace)
+```ebnf
+Filter = { Rule };
+Rule = Key, ":", Or;
+Or = And, { ",", And};
+And = Not, { "&", Not };
+Not = [ "!" ], ( Value | Range );
+Range = [ Value ], "-", [ Value ];
+Key = RawString;
+Value = EscapedString | RawString;
+EscapedString = '"', { ? any character except " ? }, '"';
+RawString = { ? any character except the used special characters ? };
+```
+
+## Targets and their keys
+
+There are 5 different targets a filter might be applied to:
+
+- `Global` which can be applied everywhere any of the other targets can be applied
+- `Domain`
+- `Host`
+- `Port`
+- `Service`
+
+### Keys
+
+Each target has its own set of allowed keys:
+
+| Target        | Key         | Type                  | Example                                                    |
+|---------------|-------------|-----------------------|------------------------------------------------------------|
+| *all targets* | tag[s]      | string                | `tag: critical`                                            | 
+|               | createdAt   | time range            | `createdAt: "2012-12-12T12:00:00Z"-"2012-12-13T12:00:00Z"` | 
+| **Domain**    | domain[s]   | string                | `domain: docs.kraken-project.org`                          | 
+|               | ip[s]       | ip address or network | `ip: 127.0.0.1`, `ip: 127.0.0.1/24`                        |
+|               | sourceOf    | string                | `sourceOf: docs.kraken-project.org`                        | 
+|               | targetOf    | string                | `targetOf: docs.kraken-project.org`                        | 
+| **Host**      | ip[s]       | ip address or network | `ip: 127.0.0.1`, `ip: 127.0.0.1/24`                        |
+|               | port[s]     | port number  or range | `port: 80`, ` port: 1-1000`                                |
+|               | service[s]  | string                | `service: http`                                            |
+|               | domain[s]   | string                | `domain: docs.kraken-project.org`                          |
+| **Port**      | port[s]     | port number or range  | `port: 80`, `port: 1-1000`                                 |
+|               | ip[s]       | ip address or network | `ip: 127.0.0.1`, `ip: 127.0.0.1/24`                        |
+|               | protocol[s] | port protocol         | `protocol: tcp`                                            |
+|               | service[s]  | string                | `service: http`                                            |
+| **Service**   | service[s]  | string                | `service: http`                                            |
+|               | ip[s]       | ip address or network | `ip: 127.0.0.1`, `ip: 127.0.0.1/24`                        |
+|               | port[s]     | port number  or range | `port: 80`, `port: 1-1000`                                 |
+|               | protocol[s] | port protocol         | `protocol: tcp`                                            |
+
+### Subkeys
+
+The keys `domain`, `sourceOf`, `targetOf`, `ip`, `port` and `service` each represent a target.
+
+You can use subkeys to query a different property of those targets instead of their main ones.
+
+For example `port.protocol: tcp` on a `Host` would filter for TCP ports instead of a specific port number.
+
+| Target      | Key        | Subkey      | Type                 | Example                                                             |
+|-------------|------------|-------------|----------------------|---------------------------------------------------------------------|
+| **Domain**  | ip[s]      | tag[s]      | string               | `ip.tag: critical`                                                  | 
+|             |            | createdAt   | time range           | `ip.createdAt: "2012-12-12T12:00:00Z"-"2012-12-13T12:00:00Z"`       | 
+|             | sourceOf   | tag[s]      | string               | `sourceOf.tag: critical`                                            | 
+|             |            | createdAt   | time range           | `sourceOf.createdAt: "2012-12-12T12:00:00Z"-"2012-12-13T12:00:00Z"` | 
+|             | targetOf   | tag[s]      | string               | `targetOf.tag: critical`                                            | 
+|             |            | createdAt   | time range           | `targetOf.createdAt: "2012-12-12T12:00:00Z"-"2012-12-13T12:00:00Z"` | 
+| **Host**    | port[s]    | protocol[s] | port protocol        | `port.protocol: tcp`                                                |
+|             |            | tag[s]      | port protocol        | `port.tag: critical`                                                |
+|             |            | createdAt   | time range           | `port.createdAt: "2012-12-12T12:00:00Z"-"2012-12-13T12:00:00Z"`     | 
+|             | service[s] | port[s]     | port number or range | `service.port: 80`, `service.port: 1-1000`                          |
+|             |            | protocol[s] | port protocol        | `serivce.protocol: tcp`                                             |
+|             |            | tag[s]      | port protocol        | `service.tag: critical`                                             |
+|             |            | createdAt   | time range           | `service.createdAt: "2012-12-12T12:00:00Z"-"2012-12-13T12:00:00Z"`  |
+|             | domain[s]  | tag[s]      | string               | `domain.tag: critical`                                              | 
+|             |            | createdAt   | time range           | `domain.createdAt: "2012-12-12T12:00:00Z"-"2012-12-13T12:00:00Z"`   | 
+| **Port**    | ip[s]      | tag[s]      | string               | `ip.tag: critical`                                                  | 
+|             |            | createdAt   | time range           | `ip.createdAt: "2012-12-12T12:00:00Z"-"2012-12-13T12:00:00Z"`       | 
+|             | service[s] | tag[s]      | string               | `service.tag: critical`                                             | 
+|             |            | createdAt   | time range           | `service.createdAt: "2012-12-12T12:00:00Z"-"2012-12-13T12:00:00Z"`  |
+| **Service** | ip[s]      | tag[s]      | string               | `ip.tag: critical`                                                  | 
+|             |            | createdAt   | time range           | `ip.createdAt: "2012-12-12T12:00:00Z"-"2012-12-13T12:00:00Z"`       | 
+|             | port[s]    | tag[s]      | string               | `port.tag: critical`                                                | 
+|             |            | createdAt   | time range           | `port.createdAt: "2012-12-12T12:00:00Z"-"2012-12-13T12:00:00Z"`     | 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -44,7 +44,8 @@ nav:
   - Home: index.md
   - Installation: installation/index.md
   - Administration: administration/index.md
-  - User guide: user/index.md
+  - User guide:
+      - Filter: user/filter.md
   - Contribution:
       - General information: contribution/index.md
       - Development Environment: contribution/dev_setup.md

--- a/kraken/src/modules/filter/mod.rs
+++ b/kraken/src/modules/filter/mod.rs
@@ -48,6 +48,33 @@ pub struct HostAST {
 
     /// Filter by ip address
     pub ips: Option<Or<IpNetwork>>,
+
+    /// Filter hosts by their ports
+    pub ports: Option<Or<MaybeRange<u16>>>,
+
+    /// Filter hosts by their ports' protocols
+    pub ports_protocols: Option<Or<PortProtocol>>,
+
+    /// Filter hosts by their ports' tags
+    pub ports_tags: Option<Or<String>>,
+
+    /// Filter hosts by their ports' creation time
+    pub ports_created_at: Option<Or<Range<DateTime<Utc>>>>,
+
+    /// Filter hosts by their services
+    pub services: Option<Or<String>>,
+
+    /// Filter hosts by their services' ports
+    pub services_ports: Option<Or<MaybeRange<u16>>>,
+
+    /// Filter hosts by their services' protocols
+    pub services_protocols: Option<Or<PortProtocol>>,
+
+    /// Filter hosts by their services' tags
+    pub services_tags: Option<Or<String>>,
+
+    /// Filter hosts by their services' creation time
+    pub services_created_at: Option<Or<Range<DateTime<Utc>>>>,
 }
 
 /// AST for port specific filter
@@ -73,6 +100,15 @@ pub struct PortAST {
 
     /// Filter by protocols
     pub protocols: Option<Or<PortProtocol>>,
+
+    /// Filter ports by their services
+    pub services: Option<Or<String>>,
+
+    /// Filter ports by their services' tags
+    pub services_tags: Option<Or<String>>,
+
+    /// Filter ports by their services' creation time
+    pub services_created_at: Option<Or<Range<DateTime<Utc>>>>,
 }
 
 /// AST for service specific filter

--- a/kraken/src/modules/filter/mod.rs
+++ b/kraken/src/modules/filter/mod.rs
@@ -65,6 +65,12 @@ pub struct PortAST {
     /// Filter by ip address
     pub ips: Option<Or<IpNetwork>>,
 
+    /// Filter ports by their hosts' creation time
+    pub ips_created_at: Option<Or<Range<DateTime<Utc>>>>,
+
+    /// Filter ports by their hosts' tags
+    pub ips_tags: Option<Or<String>>,
+
     /// Filter by protocols
     pub protocols: Option<Or<PortProtocol>>,
 }
@@ -81,8 +87,23 @@ pub struct ServiceAST {
     /// Filter by ip address
     pub ips: Option<Or<IpNetwork>>,
 
+    /// Filter services by their hosts' creation time
+    pub ips_created_at: Option<Or<Range<DateTime<Utc>>>>,
+
+    /// Filter services by their hosts' tags
+    pub ips_tags: Option<Or<String>>,
+
     /// Filter by ports
     pub ports: Option<Or<MaybeRange<u16>>>,
+
+    /// Filter services by their ports' tags
+    pub ports_tags: Option<Or<String>>,
+
+    /// Filter services by their ports' creation time
+    pub ports_created_at: Option<Or<Range<DateTime<Utc>>>>,
+
+    /// Filter services by their ports' protocols
+    pub protocols: Option<Or<PortProtocol>>,
 
     /// Filter by service name
     pub services: Option<Or<String>>,

--- a/kraken/src/modules/filter/mod.rs
+++ b/kraken/src/modules/filter/mod.rs
@@ -35,6 +35,33 @@ pub struct DomainAST {
 
     /// Filter by domain name
     pub domains: Option<Or<String>>,
+
+    /// Filter domains by their targets
+    pub source_of: Option<Or<String>>,
+
+    /// Filter domains by their targets' tags
+    pub source_of_tags: Option<Or<String>>,
+
+    /// Filter domains by their targets' creation time
+    pub source_of_created_at: Option<Or<Range<DateTime<Utc>>>>,
+
+    /// Filter domains by their sources
+    pub target_of: Option<Or<String>>,
+
+    /// Filter domains by their sources' tags
+    pub target_of_tags: Option<Or<String>>,
+
+    /// Filter domains by their sources' creation time
+    pub target_of_created_at: Option<Or<Range<DateTime<Utc>>>>,
+
+    /// Filter domains by their hosts
+    pub ips: Option<Or<IpNetwork>>,
+
+    /// Filter domains by their hosts' creation time
+    pub ips_created_at: Option<Or<Range<DateTime<Utc>>>>,
+
+    /// Filter domains by their hosts' tags
+    pub ips_tags: Option<Or<String>>,
 }
 
 /// AST for host specific filter
@@ -75,6 +102,15 @@ pub struct HostAST {
 
     /// Filter hosts by their services' creation time
     pub services_created_at: Option<Or<Range<DateTime<Utc>>>>,
+
+    /// Filter hosts by their domains' tags
+    pub domains: Option<Or<String>>,
+
+    /// Filter hosts by their domains
+    pub domains_tags: Option<Or<String>>,
+
+    /// Filter hosts by their domains
+    pub domains_created_at: Option<Or<Range<DateTime<Utc>>>>,
 }
 
 /// AST for port specific filter

--- a/kraken/src/modules/filter/parser/mod.rs
+++ b/kraken/src/modules/filter/parser/mod.rs
@@ -19,7 +19,7 @@ impl GlobalAST {
             input,
             |GlobalAST { tags, created_at }, column, tokens| match column {
                 "tags" | "tag" => parse_ast_field(tags, tokens, parse_string),
-                "created_at" => parse_ast_field(
+                "createdAt" => parse_ast_field(
                     created_at,
                     tokens,
                     wrap_range(parse_from_str::<DateTime<Utc>>),
@@ -43,7 +43,7 @@ impl DomainAST {
              column,
              tokens| match column {
                 "tags" | "tag" => parse_ast_field(tags, tokens, parse_string),
-                "created_at" => parse_ast_field(
+                "createdAt" => parse_ast_field(
                     created_at,
                     tokens,
                     wrap_range(parse_from_str::<DateTime<Utc>>),
@@ -68,7 +68,7 @@ impl HostAST {
              column,
              tokens| match column {
                 "tags" | "tag" => parse_ast_field(tags, tokens, parse_string),
-                "created_at" => parse_ast_field(
+                "createdAt" => parse_ast_field(
                     created_at,
                     tokens,
                     wrap_range(parse_from_str::<DateTime<Utc>>),
@@ -89,13 +89,15 @@ impl PortAST {
                  tags,
                  ports,
                  ips,
+                 ips_created_at,
+                 ips_tags,
                  protocols,
                  created_at,
              },
              column,
              tokens| match column {
                 "tags" | "tag" => parse_ast_field(tags, tokens, parse_string),
-                "created_at" => parse_ast_field(
+                "createdAt" => parse_ast_field(
                     created_at,
                     tokens,
                     wrap_range(parse_from_str::<DateTime<Utc>>),
@@ -104,6 +106,14 @@ impl PortAST {
                     parse_ast_field(ports, tokens, wrap_maybe_range(parse_from_str::<u16>))
                 }
                 "ips" | "ip" => parse_ast_field(ips, tokens, parse_from_str::<IpNetwork>),
+                "ips.createdAt" | "ip.createdAt" => parse_ast_field(
+                    ips_created_at,
+                    tokens,
+                    wrap_range(parse_from_str::<DateTime<Utc>>),
+                ),
+                "ips.tags" | "ips.tag" | "ip.tags" | "ip.tag" => {
+                    parse_ast_field(ips_tags, tokens, parse_string)
+                }
                 "protocols" | "protocol" => parse_ast_field(protocols, tokens, parse_port_protocol),
                 _ => Err(ParseError::UnknownColumn(column.to_string())),
             },
@@ -120,22 +130,44 @@ impl ServiceAST {
                  tags,
                  created_at,
                  ips,
+                 ips_created_at,
+                 ips_tags,
+                 ports_tags,
+                 ports_created_at,
+                 protocols,
                  services,
                  ports,
              },
              column,
              tokens| match column {
                 "tags" | "tag" => parse_ast_field(tags, tokens, parse_string),
-                "created_at" => parse_ast_field(
+                "createdAt" => parse_ast_field(
                     created_at,
                     tokens,
                     wrap_range(parse_from_str::<DateTime<Utc>>),
                 ),
                 "ips" | "ip" => parse_ast_field(ips, tokens, parse_from_str::<IpNetwork>),
+                "ips.createdAt" | "ip.createdAt" => parse_ast_field(
+                    ips_created_at,
+                    tokens,
+                    wrap_range(parse_from_str::<DateTime<Utc>>),
+                ),
+                "ip.tag" | "ip.tags" | "ips.tag" | "ips.tags" => {
+                    parse_ast_field(ips_tags, tokens, parse_string)
+                }
                 "services" | "service" => parse_ast_field(services, tokens, parse_string),
                 "ports" | "port" => {
                     parse_ast_field(ports, tokens, wrap_maybe_range(parse_from_str::<u16>))
                 }
+                "ports.createdAt" | "port.createdAt" => parse_ast_field(
+                    ports_created_at,
+                    tokens,
+                    wrap_range(parse_from_str::<DateTime<Utc>>),
+                ),
+                "port.tag" | "port.tags" | "ports.tag" | "ports.tags" => {
+                    parse_ast_field(ports_tags, tokens, parse_string)
+                }
+                "protocols" | "protocol" => parse_ast_field(protocols, tokens, parse_port_protocol),
                 _ => Err(ParseError::UnknownColumn(column.to_string())),
             },
         )

--- a/kraken/src/modules/filter/parser/mod.rs
+++ b/kraken/src/modules/filter/parser/mod.rs
@@ -39,6 +39,15 @@ impl DomainAST {
                  tags,
                  domains,
                  created_at,
+                 source_of,
+                 source_of_tags,
+                 source_of_created_at,
+                 target_of,
+                 target_of_tags,
+                 target_of_created_at,
+                 ips,
+                 ips_created_at,
+                 ips_tags,
              },
              column,
              tokens| match column {
@@ -49,6 +58,33 @@ impl DomainAST {
                     wrap_range(parse_from_str::<DateTime<Utc>>),
                 ),
                 "domains" | "domain" => parse_ast_field(domains, tokens, parse_string),
+                "sourceOf" => parse_ast_field(source_of, tokens, parse_string),
+                "sourceOf.tags" | "sourceOf.tag" => {
+                    parse_ast_field(source_of_tags, tokens, parse_string)
+                }
+                "sourceOf.createdAt" => parse_ast_field(
+                    source_of_created_at,
+                    tokens,
+                    wrap_range(parse_from_str::<DateTime<Utc>>),
+                ),
+                "targetOf" => parse_ast_field(target_of, tokens, parse_string),
+                "targetOf.tags" | "targetOf.tag" => {
+                    parse_ast_field(target_of_tags, tokens, parse_string)
+                }
+                "targetOf.createdAt" => parse_ast_field(
+                    target_of_created_at,
+                    tokens,
+                    wrap_range(parse_from_str::<DateTime<Utc>>),
+                ),
+                "ips" | "ip" => parse_ast_field(ips, tokens, parse_from_str::<IpNetwork>),
+                "ips.tags" | "ips.tag" | "ip.tags" | "ip.tag" => {
+                    parse_ast_field(ips_tags, tokens, parse_string)
+                }
+                "ips.createdAt" | "ip.createdAt" => parse_ast_field(
+                    ips_created_at,
+                    tokens,
+                    wrap_range(parse_from_str::<DateTime<Utc>>),
+                ),
                 _ => Err(ParseError::UnknownColumn(column.to_string())),
             },
         )
@@ -73,6 +109,9 @@ impl HostAST {
                  services_protocols,
                  services_tags,
                  services_created_at,
+                 domains,
+                 domains_tags,
+                 domains_created_at,
              },
              column,
              tokens| match column {
@@ -114,6 +153,15 @@ impl HostAST {
                 }
                 "services.createdAt" | "service.createdAt" => parse_ast_field(
                     services_created_at,
+                    tokens,
+                    wrap_range(parse_from_str::<DateTime<Utc>>),
+                ),
+                "domains" | "domain" => parse_ast_field(domains, tokens, parse_string),
+                "domains.tags" | "domains.tag" | "domain.tags" | "domain.tag" => {
+                    parse_ast_field(domains_tags, tokens, parse_string)
+                }
+                "domains.createdAt" | "domain.createdAt" => parse_ast_field(
+                    domains_created_at,
                     tokens,
                     wrap_range(parse_from_str::<DateTime<Utc>>),
                 ),

--- a/kraken/src/modules/filter/parser/mod.rs
+++ b/kraken/src/modules/filter/parser/mod.rs
@@ -64,6 +64,15 @@ impl HostAST {
                  tags,
                  ips,
                  created_at,
+                 ports,
+                 ports_created_at,
+                 ports_protocols: ports_protocol,
+                 ports_tags,
+                 services,
+                 services_ports,
+                 services_protocols,
+                 services_tags,
+                 services_created_at,
              },
              column,
              tokens| match column {
@@ -74,6 +83,40 @@ impl HostAST {
                     wrap_range(parse_from_str::<DateTime<Utc>>),
                 ),
                 "ips" | "ip" => parse_ast_field(ips, tokens, parse_from_str::<IpNetwork>),
+                "ports" | "port" => {
+                    parse_ast_field(ports, tokens, wrap_maybe_range(parse_from_str::<u16>))
+                }
+                "ports.createdAt" | "port.createdAt" => parse_ast_field(
+                    ports_created_at,
+                    tokens,
+                    wrap_range(parse_from_str::<DateTime<Utc>>),
+                ),
+                "ports.protocols" | "ports.protocol" | "port.protocols" | "port.protocol" => {
+                    parse_ast_field(ports_protocol, tokens, parse_port_protocol)
+                }
+                "ports.tags" | "ports.tag" | "port.tags" | "port.tag" => {
+                    parse_ast_field(ports_tags, tokens, parse_string)
+                }
+                "services" | "service" => parse_ast_field(services, tokens, parse_string),
+                "services.ports" | "services.port" | "service.ports" | "service.port" => {
+                    parse_ast_field(
+                        services_ports,
+                        tokens,
+                        wrap_maybe_range(parse_from_str::<u16>),
+                    )
+                }
+                "services.protocols" | "services.protocol" | "service.protocols"
+                | "service.protocol" => {
+                    parse_ast_field(services_protocols, tokens, parse_port_protocol)
+                }
+                "services.tags" | "services.tag" | "service.tags" | "service.tag" => {
+                    parse_ast_field(services_tags, tokens, parse_string)
+                }
+                "services.createdAt" | "service.createdAt" => parse_ast_field(
+                    services_created_at,
+                    tokens,
+                    wrap_range(parse_from_str::<DateTime<Utc>>),
+                ),
                 _ => Err(ParseError::UnknownColumn(column.to_string())),
             },
         )
@@ -93,6 +136,9 @@ impl PortAST {
                  ips_tags,
                  protocols,
                  created_at,
+                 services,
+                 services_tags,
+                 services_created_at,
              },
              column,
              tokens| match column {
@@ -115,6 +161,15 @@ impl PortAST {
                     parse_ast_field(ips_tags, tokens, parse_string)
                 }
                 "protocols" | "protocol" => parse_ast_field(protocols, tokens, parse_port_protocol),
+                "services" | "service" => parse_ast_field(services, tokens, parse_string),
+                "services.tags" | "services.tag" | "service.tags" | "service.tag" => {
+                    parse_ast_field(services_tags, tokens, parse_string)
+                }
+                "services.createdAt" | "service.createdAt" => parse_ast_field(
+                    services_created_at,
+                    tokens,
+                    wrap_range(parse_from_str::<DateTime<Utc>>),
+                ),
                 _ => Err(ParseError::UnknownColumn(column.to_string())),
             },
         )

--- a/kraken/src/modules/filter/parser/value_parser.rs
+++ b/kraken/src/modules/filter/parser/value_parser.rs
@@ -32,7 +32,7 @@ pub fn parse_port_protocol(tokens: &mut Cursor) -> Result<PortProtocol, ParseErr
     let string = tokens.next_value()?;
     if string.eq_ignore_ascii_case("tcp") {
         Ok(PortProtocol::Tcp)
-    } else if string.eq_ignore_ascii_case("ucp") {
+    } else if string.eq_ignore_ascii_case("udp") {
         Ok(PortProtocol::Udp)
     } else if string.eq_ignore_ascii_case("sctp") {
         Ok(PortProtocol::Sctp)

--- a/kraken/src/modules/filter/sqler/mod.rs
+++ b/kraken/src/modules/filter/sqler/mod.rs
@@ -10,10 +10,7 @@ use rorm::prelude::*;
 
 use crate::models::{Domain, Host, Port, Service};
 use crate::modules::filter::sqler::joins::{JoinPorts, JoinTags};
-use crate::modules::filter::sqler::value_sqler::{
-    CreatedAtSqler, IpSqler, NullablePortSqler, PortProtocolSqler, PortSqler, StringEqSqler,
-    TagSqler, ValueSqler,
-};
+use crate::modules::filter::sqler::value_sqler::{Column, ValueSqler};
 use crate::modules::filter::{And, DomainAST, GlobalAST, HostAST, Not, Or, PortAST, ServiceAST};
 use crate::modules::raw_query::RawQueryBuilder;
 
@@ -35,14 +32,13 @@ impl DomainAST {
             created_at,
             domains,
         } = self;
-        add_ast_field(sql, tags, TagSqler);
-        add_ast_field(sql, tags, TagSqler);
-        add_ast_field(sql, created_at, CreatedAtSqler::new(Domain::F.created_at));
-        add_ast_field(sql, domains, StringEqSqler::new(Domain::F.domain));
+        add_ast_field(sql, tags, Column::tags().contains());
+        add_ast_field(sql, created_at, Column::rorm(Domain::F.created_at).range());
+        add_ast_field(sql, domains, Column::rorm(Domain::F.domain).eq());
 
         let GlobalAST { tags, created_at } = global;
-        add_ast_field(sql, tags, TagSqler);
-        add_ast_field(sql, created_at, CreatedAtSqler::new(Domain::F.created_at));
+        add_ast_field(sql, tags, Column::tags().contains());
+        add_ast_field(sql, created_at, Column::rorm(Domain::F.created_at).range());
     }
 }
 impl HostAST {
@@ -63,13 +59,13 @@ impl HostAST {
             created_at,
             ips,
         } = self;
-        add_ast_field(sql, tags, TagSqler);
-        add_ast_field(sql, created_at, CreatedAtSqler::new(Host::F.created_at));
-        add_ast_field(sql, ips, IpSqler::new(Host::F.ip_addr));
+        add_ast_field(sql, tags, Column::tags().contains());
+        add_ast_field(sql, created_at, Column::rorm(Host::F.created_at).range());
+        add_ast_field(sql, ips, Column::rorm(Host::F.ip_addr).subnet());
 
         let GlobalAST { tags, created_at } = global;
-        add_ast_field(sql, tags, TagSqler);
-        add_ast_field(sql, created_at, CreatedAtSqler::new(Host::F.created_at));
+        add_ast_field(sql, tags, Column::tags().contains());
+        add_ast_field(sql, created_at, Column::rorm(Host::F.created_at).range());
     }
 }
 impl PortAST {
@@ -92,15 +88,15 @@ impl PortAST {
             ips,
             protocols,
         } = self;
-        add_ast_field(sql, tags, TagSqler);
-        add_ast_field(sql, created_at, CreatedAtSqler::new(Port::F.created_at));
-        add_ast_field(sql, ports, PortSqler::new(Port::F.port));
-        add_ast_field(sql, ips, IpSqler::new(Port::F.host.ip_addr));
-        add_ast_field(sql, protocols, PortProtocolSqler::new(Port::F.protocol));
+        add_ast_field(sql, tags, Column::tags().contains());
+        add_ast_field(sql, created_at, Column::rorm(Port::F.created_at).range());
+        add_ast_field(sql, ports, Column::rorm(Port::F.port).maybe_range());
+        add_ast_field(sql, ips, Column::rorm(Port::F.host.ip_addr).subnet());
+        add_ast_field(sql, protocols, Column::rorm(Port::F.protocol).eq());
 
         let GlobalAST { tags, created_at } = global;
-        add_ast_field(sql, tags, TagSqler);
-        add_ast_field(sql, created_at, CreatedAtSqler::new(Port::F.created_at));
+        add_ast_field(sql, tags, Column::tags().contains());
+        add_ast_field(sql, created_at, Column::rorm(Port::F.created_at).range());
     }
 }
 impl ServiceAST {
@@ -126,19 +122,19 @@ impl ServiceAST {
             services,
             ports,
         } = self;
-        add_ast_field(sql, tags, TagSqler);
-        add_ast_field(sql, created_at, CreatedAtSqler::new(Service::F.created_at));
-        add_ast_field(sql, ips, IpSqler::new(Service::F.host.ip_addr));
-        add_ast_field(sql, services, StringEqSqler::new(Service::F.name));
+        add_ast_field(sql, tags, Column::tags().contains());
+        add_ast_field(sql, created_at, Column::rorm(Service::F.created_at).range());
+        add_ast_field(sql, ips, Column::rorm(Service::F.host.ip_addr).subnet());
+        add_ast_field(sql, services, Column::rorm(Service::F.name).eq());
         add_ast_field(
             sql,
             ports,
-            NullablePortSqler(PortSqler::new(Port::F.port)), // This table is joined manually
+            Column::rorm(Port::F.port).nullable_maybe_range(), // This table is joined manually
         );
 
         let GlobalAST { tags, created_at } = global;
-        add_ast_field(sql, tags, TagSqler);
-        add_ast_field(sql, created_at, CreatedAtSqler::new(Service::F.created_at));
+        add_ast_field(sql, tags, Column::tags().contains());
+        add_ast_field(sql, created_at, Column::rorm(Service::F.created_at).range());
     }
 }
 

--- a/kraken/src/modules/raw_query.rs
+++ b/kraken/src/modules/raw_query.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 use std::fmt::Write;
+use std::mem::swap;
 
 use futures::{Stream, StreamExt};
 use log::debug;
@@ -81,6 +82,27 @@ impl<'a, S: Selector> RawQueryBuilder<'a, S> {
             values: Vec::new(),
             position: QueryBuilderPosition::Join,
         }
+    }
+
+    /// Use the handles (`sql` and `values`) which are passed out by methods like [`append_condition`]
+    /// to write a subquery.
+    ///
+    /// The subquery will be automatically wrapped in parentheses.
+    pub fn write_subquery(
+        sql: &mut String,
+        values: &mut Vec<Value<'a>>,
+        selector: S,
+        write: impl FnOnce(&mut RawQueryBuilder<'a, S>),
+    ) {
+        let mut builder = RawQueryBuilder::new(selector);
+        sql.push('(');
+        sql.push_str(&builder.sql); // Write the "select from" generated in RawQueryBuilder::new
+        swap(sql, &mut builder.sql);
+        swap(values, &mut builder.values);
+        write(&mut builder);
+        swap(sql, &mut builder.sql);
+        swap(values, &mut builder.values);
+        sql.push(')');
     }
 
     /// Append a `JOIN`

--- a/kraken_frontend/src/utils/filter/ast.ts
+++ b/kraken_frontend/src/utils/filter/ast.ts
@@ -1,39 +1,47 @@
 import { PortProtocol } from "../../api/generated";
 
 export type GlobalAST = {
-    tags: Array<Expr.Or<string>>;
-    createdAt: Array<Expr.Or<Expr.Range<Date>>>;
+    tags: Exprs<string>;
+    createdAt: Exprs<Expr.Range<Date>>;
 };
 
 export type DomainAST = {
-    tags: Array<Expr.Or<string>>;
-    createdAt: Array<Expr.Or<Expr.Range<Date>>>;
-    domains: Array<Expr.Or<string>>;
+    tags: Exprs<string>;
+    createdAt: Exprs<Expr.Range<Date>>;
+    domains: Exprs<string>;
 };
 
 export type HostAST = {
-    tags: Array<Expr.Or<string>>;
-    createdAt: Array<Expr.Or<Expr.Range<Date>>>;
-    ips: Array<Expr.Or<string>>;
+    tags: Exprs<string>;
+    createdAt: Exprs<Expr.Range<Date>>;
+    ips: Exprs<string>;
 };
 
 export type PortAST = {
-    tags: Array<Expr.Or<string>>;
-    createdAt: Array<Expr.Or<Expr.Range<Date>>>;
-    ports: Array<Expr.Or<Expr.MaybeRange<number>>>;
-    ips: Array<Expr.Or<string>>;
-    protocols: Array<Expr.Or<PortProtocol>>;
+    tags: Exprs<string>;
+    createdAt: Exprs<Expr.Range<Date>>;
+    ports: Exprs<Expr.MaybeRange<number>>;
+    ips: Exprs<string>;
+    ipsCreatedAt: Exprs<Expr.Range<Date>>;
+    ipsTags: Exprs<string>;
+    protocols: Exprs<PortProtocol>;
 };
 
 export type ServiceAST = {
-    tags: Array<Expr.Or<string>>;
-    createdAt: Array<Expr.Or<Expr.Range<Date>>>;
-    ips: Array<Expr.Or<string>>;
-    ports: Array<Expr.Or<Expr.MaybeRange<number>>>;
-    services: Array<Expr.Or<string>>;
+    tags: Exprs<string>;
+    createdAt: Exprs<Expr.Range<Date>>;
+    ips: Exprs<string>;
+    ipsCreatedAt: Exprs<Expr.Range<Date>>;
+    ipsTags: Exprs<string>;
+    ports: Exprs<Expr.MaybeRange<number>>;
+    portsTags: Exprs<string>;
+    portsCreatedAt: Exprs<Expr.Range<Date>>;
+    protocols: Exprs<PortProtocol>;
+    services: Exprs<string>;
 };
 
 export type Expr<T> = Expr.Or<T>;
+export type Exprs<T> = Array<Expr.Or<T>>;
 
 export namespace Expr {
     /** An optional `or` */

--- a/kraken_frontend/src/utils/filter/ast.ts
+++ b/kraken_frontend/src/utils/filter/ast.ts
@@ -15,6 +15,17 @@ export type HostAST = {
     tags: Exprs<string>;
     createdAt: Exprs<Expr.Range<Date>>;
     ips: Exprs<string>;
+
+    ports: Exprs<Expr.MaybeRange<number>>;
+    portsProtocols: Exprs<PortProtocol>;
+    portsTags: Exprs<string>;
+    portsCreatedAt: Exprs<Expr.Range<Date>>;
+
+    services: Exprs<string>;
+    servicesPorts: Exprs<Expr.MaybeRange<number>>;
+    servicesProtocols: Exprs<PortProtocol>;
+    servicesTags: Exprs<string>;
+    servicesCreatedAt: Exprs<Expr.Range<Date>>;
 };
 
 export type PortAST = {
@@ -25,6 +36,10 @@ export type PortAST = {
     ipsCreatedAt: Exprs<Expr.Range<Date>>;
     ipsTags: Exprs<string>;
     protocols: Exprs<PortProtocol>;
+
+    services: Exprs<string>;
+    servicesTags: Exprs<string>;
+    servicesCreatedAt: Exprs<Expr.Range<Date>>;
 };
 
 export type ServiceAST = {

--- a/kraken_frontend/src/utils/filter/ast.ts
+++ b/kraken_frontend/src/utils/filter/ast.ts
@@ -9,23 +9,33 @@ export type DomainAST = {
     tags: Exprs<string>;
     createdAt: Exprs<Expr.Range<Date>>;
     domains: Exprs<string>;
+    sourceOf: Exprs<string>;
+    sourceOfTags: Exprs<string>;
+    sourceOfCreatedAt: Exprs<Expr.Range<Date>>;
+    targetOf: Exprs<string>;
+    targetOfTags: Exprs<string>;
+    targetOfCreatedAt: Exprs<Expr.Range<Date>>;
+    ips: Exprs<string>;
+    ipsCreatedAt: Exprs<Expr.Range<Date>>;
+    ipsTags: Exprs<string>;
 };
 
 export type HostAST = {
     tags: Exprs<string>;
     createdAt: Exprs<Expr.Range<Date>>;
     ips: Exprs<string>;
-
     ports: Exprs<Expr.MaybeRange<number>>;
     portsProtocols: Exprs<PortProtocol>;
     portsTags: Exprs<string>;
     portsCreatedAt: Exprs<Expr.Range<Date>>;
-
     services: Exprs<string>;
     servicesPorts: Exprs<Expr.MaybeRange<number>>;
     servicesProtocols: Exprs<PortProtocol>;
     servicesTags: Exprs<string>;
     servicesCreatedAt: Exprs<Expr.Range<Date>>;
+    domains: Exprs<string>;
+    domainsTags: Exprs<string>;
+    domainsCreatedAt: Exprs<Expr.Range<Date>>;
 };
 
 export type PortAST = {
@@ -36,7 +46,6 @@ export type PortAST = {
     ipsCreatedAt: Exprs<Expr.Range<Date>>;
     ipsTags: Exprs<string>;
     protocols: Exprs<PortProtocol>;
-
     services: Exprs<string>;
     servicesTags: Exprs<string>;
     servicesCreatedAt: Exprs<Expr.Range<Date>>;

--- a/kraken_frontend/src/utils/filter/parser.ts
+++ b/kraken_frontend/src/utils/filter/parser.ts
@@ -18,7 +18,7 @@ export function parseGlobalAST(input: string): GlobalAST {
             case "tag":
                 ast.tags.push(parseOr(cursor, parseString));
                 break;
-            case "created_at":
+            case "createdAt":
                 ast.createdAt.push(parseOr(cursor, wrapRange(parseDate)));
                 break;
             default:
@@ -41,7 +41,7 @@ export function parseDomainAST(input: string): DomainAST {
             case "tag":
                 ast.tags.push(parseOr(cursor, parseString));
                 break;
-            case "created_at":
+            case "createdAt":
                 ast.createdAt.push(parseOr(cursor, wrapRange(parseDate)));
                 break;
             case "domains":
@@ -68,7 +68,7 @@ export function parseHostAST(input: string): HostAST {
             case "tag":
                 ast.tags.push(parseOr(cursor, parseString));
                 break;
-            case "created_at":
+            case "createdAt":
                 ast.createdAt.push(parseOr(cursor, wrapRange(parseDate)));
                 break;
             case "ips":
@@ -88,14 +88,14 @@ export function parseHostAST(input: string): HostAST {
  * @throws ParserError
  */
 export function parsePortAST(input: string): PortAST {
-    const ast: PortAST = { tags: [], createdAt: [], ports: [], ips: [], protocols: [] };
+    const ast: PortAST = { tags: [], createdAt: [], ports: [], ips: [], protocols: [], ipsTags: [], ipsCreatedAt: [] };
     parseAst(input, (column, cursor) => {
         switch (column) {
             case "tags":
             case "tag":
                 ast.tags.push(parseOr(cursor, parseString));
                 break;
-            case "created_at":
+            case "createdAt":
                 ast.createdAt.push(parseOr(cursor, wrapRange(parseDate)));
                 break;
             case "ports":
@@ -105,6 +105,16 @@ export function parsePortAST(input: string): PortAST {
             case "ips":
             case "ip":
                 ast.ips.push(parseOr(cursor, parseString));
+                break;
+            case "ips.tags":
+            case "ips.tag":
+            case "ip.tags":
+            case "ip.tag":
+                ast.ipsTags.push(parseOr(cursor, parseString));
+                break;
+            case "ips.createdAt":
+            case "ip.createdAt":
+                ast.ipsCreatedAt.push(parseOr(cursor, wrapRange(parseDate)));
                 break;
             case "protocols":
             case "protocol":
@@ -123,23 +133,58 @@ export function parsePortAST(input: string): PortAST {
  * @throws ParserError
  */
 export function parseServiceAST(input: string): ServiceAST {
-    const ast: ServiceAST = { tags: [], createdAt: [], ports: [], ips: [], services: [] };
+    const ast: ServiceAST = {
+        tags: [],
+        createdAt: [],
+        ports: [],
+        ips: [],
+        services: [],
+        ipsTags: [],
+        ipsCreatedAt: [],
+        portsTags: [],
+        portsCreatedAt: [],
+        protocols: [],
+    };
     parseAst(input, (column, cursor) => {
         switch (column) {
             case "tags":
             case "tag":
                 ast.tags.push(parseOr(cursor, parseString));
                 break;
-            case "created_at":
+            case "createdAt":
                 ast.createdAt.push(parseOr(cursor, wrapRange(parseDate)));
                 break;
             case "ports":
             case "port":
                 ast.ports.push(parseOr(cursor, wrapMaybeRange(parsePort)));
                 break;
+            case "ports.tags":
+            case "ports.tag":
+            case "port.tags":
+            case "port.tag":
+                ast.portsTags.push(parseOr(cursor, parseString));
+                break;
+            case "ports.createdAt":
+            case "port.createdAt":
+                ast.portsCreatedAt.push(parseOr(cursor, wrapRange(parseDate)));
+                break;
+            case "protocols":
+            case "protocol":
+                ast.protocols.push(parseOr(cursor, parsePortProtocol));
+                break;
             case "ips":
             case "ip":
                 ast.ips.push(parseOr(cursor, parseString));
+                break;
+            case "ips.tags":
+            case "ips.tag":
+            case "ip.tags":
+            case "ip.tag":
+                ast.ipsTags.push(parseOr(cursor, parseString));
+                break;
+            case "ips.createdAt":
+            case "ip.createdAt":
+                ast.ipsCreatedAt.push(parseOr(cursor, wrapRange(parseDate)));
                 break;
             case "services":
             case "service":

--- a/kraken_frontend/src/utils/filter/parser.ts
+++ b/kraken_frontend/src/utils/filter/parser.ts
@@ -1,5 +1,5 @@
 import { Cursor } from "./cursor";
-import { DomainAST, Expr, GlobalAST, HostAST, PortAST, ServiceAST } from "./ast";
+import { DomainAST, Expr, Exprs, GlobalAST, HostAST, PortAST, ServiceAST } from "./ast";
 import { Token, tokenize } from "./lexer";
 import ParserError from "./error";
 import { Err, Result } from "../result";
@@ -61,7 +61,20 @@ export function parseDomainAST(input: string): DomainAST {
  * @throws ParserError
  */
 export function parseHostAST(input: string): HostAST {
-    const ast: HostAST = { tags: [], createdAt: [], ips: [] };
+    const ast: HostAST = {
+        tags: [],
+        createdAt: [],
+        ips: [],
+        ports: [],
+        portsProtocols: [],
+        portsTags: [],
+        portsCreatedAt: [],
+        services: [],
+        servicesPorts: [],
+        servicesProtocols: [],
+        servicesTags: [],
+        servicesCreatedAt: [],
+    };
     parseAst(input, (column, cursor) => {
         switch (column) {
             case "tags":
@@ -74,6 +87,52 @@ export function parseHostAST(input: string): HostAST {
             case "ips":
             case "ip":
                 ast.ips.push(parseOr(cursor, parseString));
+                break;
+            case "ports":
+            case "port":
+                ast.ports.push(parseOr(cursor, wrapMaybeRange(parsePort)));
+                break;
+            case "ports.protocols":
+            case "ports.protocol":
+            case "port.protocols":
+            case "port.protocol":
+                ast.portsProtocols.push(parseOr(cursor, parsePortProtocol));
+                break;
+            case "ports.tags":
+            case "ports.tag":
+            case "port.tags":
+            case "port.tag":
+                ast.portsTags.push(parseOr(cursor, parseString));
+                break;
+            case "ports.createdAt":
+            case "port.createdAt":
+                ast.portsCreatedAt.push(parseOr(cursor, wrapRange(parseDate)));
+                break;
+            case "services":
+            case "service":
+                ast.services.push(parseOr(cursor, parseString));
+                break;
+            case "services.ports":
+            case "services.port":
+            case "service.ports":
+            case "service.port":
+                ast.servicesPorts.push(parseOr(cursor, wrapMaybeRange(parsePort)));
+                break;
+            case "services.protocols":
+            case "services.protocol":
+            case "service.protocols":
+            case "service.protocol":
+                ast.servicesProtocols.push(parseOr(cursor, parsePortProtocol));
+                break;
+            case "services.tags":
+            case "services.tag":
+            case "service.tags":
+            case "service.tag":
+                ast.servicesTags.push(parseOr(cursor, parseString));
+                break;
+            case "services.createdAt":
+            case "service.createdAt":
+                ast.servicesCreatedAt.push(parseOr(cursor, wrapRange(parseDate)));
                 break;
             default:
                 throw new ParserError({ type: "unknownColumn", column });
@@ -88,7 +147,18 @@ export function parseHostAST(input: string): HostAST {
  * @throws ParserError
  */
 export function parsePortAST(input: string): PortAST {
-    const ast: PortAST = { tags: [], createdAt: [], ports: [], ips: [], protocols: [], ipsTags: [], ipsCreatedAt: [] };
+    const ast: PortAST = {
+        tags: [],
+        createdAt: [],
+        ports: [],
+        ips: [],
+        protocols: [],
+        ipsTags: [],
+        ipsCreatedAt: [],
+        services: [],
+        servicesTags: [],
+        servicesCreatedAt: [],
+    };
     parseAst(input, (column, cursor) => {
         switch (column) {
             case "tags":
@@ -119,6 +189,20 @@ export function parsePortAST(input: string): PortAST {
             case "protocols":
             case "protocol":
                 ast.protocols.push(parseOr(cursor, parsePortProtocol));
+                break;
+            case "services":
+            case "service":
+                ast.services.push(parseOr(cursor, parseString));
+                break;
+            case "services.tags":
+            case "services.tag":
+            case "service.tags":
+            case "service.tag":
+                ast.servicesTags.push(parseOr(cursor, parseString));
+                break;
+            case "services.createdAt":
+            case "service.createdAt":
+                ast.servicesCreatedAt.push(parseOr(cursor, wrapRange(parseDate)));
                 break;
             default:
                 throw new ParserError({ type: "unknownColumn", column });

--- a/kraken_frontend/src/utils/filter/parser.ts
+++ b/kraken_frontend/src/utils/filter/parser.ts
@@ -34,7 +34,20 @@ export function parseGlobalAST(input: string): GlobalAST {
  * @throws ParserError
  */
 export function parseDomainAST(input: string): DomainAST {
-    const ast: DomainAST = { tags: [], createdAt: [], domains: [] };
+    const ast: DomainAST = {
+        tags: [],
+        createdAt: [],
+        domains: [],
+        sourceOf: [],
+        sourceOfTags: [],
+        sourceOfCreatedAt: [],
+        targetOf: [],
+        targetOfTags: [],
+        targetOfCreatedAt: [],
+        ips: [],
+        ipsTags: [],
+        ipsCreatedAt: [],
+    };
     parseAst(input, (column, cursor) => {
         switch (column) {
             case "tags":
@@ -47,6 +60,40 @@ export function parseDomainAST(input: string): DomainAST {
             case "domains":
             case "domain":
                 ast.domains.push(parseOr(cursor, parseString));
+                break;
+            case "sourceOf":
+                ast.sourceOf.push(parseOr(cursor, parseString));
+                break;
+            case "sourceOf.tag":
+            case "sourceOf.tags":
+                ast.sourceOfTags.push(parseOr(cursor, parseString));
+                break;
+            case "sourceOf.createdAt":
+                ast.sourceOfCreatedAt.push(parseOr(cursor, wrapRange(parseDate)));
+                break;
+            case "targetOf":
+                ast.targetOf.push(parseOr(cursor, parseString));
+                break;
+            case "targetOf.tag":
+            case "targetOf.tags":
+                ast.targetOfTags.push(parseOr(cursor, parseString));
+                break;
+            case "targetOf.createdAt":
+                ast.targetOfCreatedAt.push(parseOr(cursor, wrapRange(parseDate)));
+                break;
+            case "ips":
+            case "ip":
+                ast.ips.push(parseOr(cursor, parseString));
+                break;
+            case "ips.tags":
+            case "ips.tag":
+            case "ip.tags":
+            case "ip.tag":
+                ast.ipsTags.push(parseOr(cursor, parseString));
+                break;
+            case "ips.createdAt":
+            case "ip.createdAt":
+                ast.ipsCreatedAt.push(parseOr(cursor, wrapRange(parseDate)));
                 break;
             default:
                 throw new ParserError({ type: "unknownColumn", column });
@@ -74,6 +121,9 @@ export function parseHostAST(input: string): HostAST {
         servicesProtocols: [],
         servicesTags: [],
         servicesCreatedAt: [],
+        domains: [],
+        domainsTags: [],
+        domainsCreatedAt: [],
     };
     parseAst(input, (column, cursor) => {
         switch (column) {
@@ -133,6 +183,20 @@ export function parseHostAST(input: string): HostAST {
             case "services.createdAt":
             case "service.createdAt":
                 ast.servicesCreatedAt.push(parseOr(cursor, wrapRange(parseDate)));
+                break;
+            case "domains":
+            case "domain":
+                ast.domains.push(parseOr(cursor, parseString));
+                break;
+            case "domains.tags":
+            case "domains.tag":
+            case "domain.tags":
+            case "domain.tag":
+                ast.domainsTags.push(parseOr(cursor, parseString));
+                break;
+            case "domains.createdAt":
+            case "domain.createdAt":
+                ast.domainsCreatedAt.push(parseOr(cursor, wrapRange(parseDate)));
                 break;
             default:
                 throw new ParserError({ type: "unknownColumn", column });


### PR DESCRIPTION
This PR extends the existing filters to allow querying through 1 relational step.

Examples:
The service filter allows  `ip: 127.0.0.1` which is one step through a foreign model (not new)
The host filter allows  `port: 80` which is one step through a back reference
The host filter allows  `domain: localhost` which is one step through a many to many relation

Additionally each of these 3 types of references now also allow querying other fields than the main one.

Examples:
`ip.tag: foo` on a service
`port.tag: foo` on a host
`domain.tag: foo` on a host

A new page has been added to the docs explaining the basic syntax and listing all keys and their subkeys.