### PR TITLE
Make IPs & domains fully selected with double click

### DIFF
--- a/kraken_frontend/src/components/selectable-text.tsx
+++ b/kraken_frontend/src/components/selectable-text.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+type SelectableTextProps = {
+    /// What kind of element should be used, defaults to `div` if unset.
+    as?: string;
+    children: any;
+} & React.HTMLAttributes<HTMLElement>;
+
+/**
+ * Component that automatically selects the whole content when you double click
+ * on it.
+ *
+ * This is useful for data elements so that the user can quickly double-click
+ * select and copy the text without trailing or leading extra whitespace
+ * otherwise added by the browser when not accurately selecting.
+ *
+ * Use sparingly! Don't use this on multi-line text, since the user won't expect
+ * this selection behavior on it. Don't use on lists of data where the user
+ * would likely want to sometimes select only a single word or part of the list.
+ *
+ * Do use this inside table cells, especially for things such as domains or IPs.
+ * Do not use this for free-form content.
+ *
+ * Doesn't select everything if the user dragged the mouse to select text with
+ * word-select mode (double click).
+ *
+ * Doesn't select everything if the user held ctrl or shift during the double
+ * click.
+ */
+export default function SelectableText(props: SelectableTextProps) {
+    // if mouse has been moved this many pixels from the first click, don't select everything
+    const MOVE_THRESHOLD = 5;
+    const As = (props.as ?? "div") as any;
+
+    let div = React.useRef(null);
+    let location = React.useRef([0, 0]);
+    return <As {...props} ref={div} onMouseDown={(e: MouseEvent) => {
+        location.current = [e.clientX, e.clientY];
+    }} onMouseMove={(e: MouseEvent) => {
+        let [x1, y1] = location.current;
+        let [x2, y2] = [e.clientX, e.clientY];
+        let d = (x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2);
+        if (d > MOVE_THRESHOLD * MOVE_THRESHOLD)
+            location.current = [NaN, NaN];
+    }} onDoubleClick={(e: MouseEvent) => {
+        const selection = window.getSelection();
+        let [x1, y1] = location.current;
+        let [x2, y2] = [e.clientX, e.clientY];
+        let d = (x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2);
+        if (div.current && selection && !e.ctrlKey && !e.shiftKey && d < MOVE_THRESHOLD * MOVE_THRESHOLD) {
+            const range = document.createRange();
+            range.selectNodeContents(div.current);
+            selection.removeAllRanges();
+            selection.addRange(range);
+        }
+    }}>{props.children}</As>;
+}

--- a/kraken_frontend/src/views/workspace/workspace-data.tsx
+++ b/kraken_frontend/src/views/workspace/workspace-data.tsx
@@ -26,6 +26,7 @@ import UnverifiedIcon from "../../svg/unverified";
 import VerifiedIcon from "../../svg/verified";
 import HistoricalIcon from "../../svg/historical";
 import UnknownIcon from "../../svg/unknown";
+import SelectableText from "../../components/selectable-text";
 
 const TABS = { domains: "Domains", hosts: "Hosts", ports: "Ports", services: "Services" };
 const DETAILS_TAB = { general: "General", results: "Results", relations: "Relations" };
@@ -143,9 +144,9 @@ export default function WorkspaceData(props: WorkspaceDataProps) {
                                     uuids={selectedUuids.domains}
                                     setUuids={(domains) => setSelectedUuids({ ...selectedUuids, domains })}
                                 />
-                                <span>{domain.domain}</span>
+                                <SelectableText>{domain.domain}</SelectableText>
                                 <TagList tags={domain.tags} />
-                                <span>{domain.comment}</span>
+                                <div>{domain.comment}</div>
                                 {domain.certainty === "Unverified"
                                     ? CertaintyIcon({ certaintyType: "Unverified" })
                                     : CertaintyIcon({ certaintyType: "Verified" })}
@@ -200,9 +201,9 @@ export default function WorkspaceData(props: WorkspaceDataProps) {
                                     uuids={selectedUuids.hosts}
                                     setUuids={(hosts) => setSelectedUuids({ ...selectedUuids, hosts })}
                                 />
-                                <span>{host.ipAddr}</span>
+                                <SelectableText>{host.ipAddr}</SelectableText>
                                 <TagList tags={host.tags} />
-                                <span>{host.comment}</span>
+                                <div>{host.comment}</div>
                                 {host.certainty === "Verified"
                                     ? CertaintyIcon({ certaintyType: "Verified" })
                                     : host.certainty === "Historical"


### PR DESCRIPTION
Still allows default browser word select using ctrl or just by moving the mouse while dragging with double click.

This fixes an annoyance with leading/trailing whitespace when copying out IPs/domains reported by someone in person.