### PR TITLE
collect error information for DNS

### DIFF
--- a/kraken_frontend/src/views/running-attacks.tsx
+++ b/kraken_frontend/src/views/running-attacks.tsx
@@ -1,13 +1,13 @@
 import React from "react";
-import "../styling/running-attacks.css";
-import RunningAttackIcon from "../svg/running-attack";
-import Popup from "reactjs-popup";
-import SuccessIcon from "../svg/success";
-import FailedIcon from "../svg/failed";
-import WS from "../api/websocket";
-import { Api, UUID } from "../api/api";
-import { AttackType, SimpleAttack, SimpleWorkspace } from "../api/generated";
 import { toast } from "react-toastify";
+import Popup from "reactjs-popup";
+import { Api, UUID } from "../api/api";
+import { SimpleAttack } from "../api/generated";
+import WS from "../api/websocket";
+import "../styling/running-attacks.css";
+import FailedIcon from "../svg/failed";
+import RunningAttackIcon from "../svg/running-attack";
+import SuccessIcon from "../svg/success";
 import { ATTACKS } from "../utils/attack-resolver";
 
 type RunningAttacksProps = {};
@@ -103,7 +103,7 @@ export default class RunningAttacks extends React.Component<RunningAttacksProps,
                                             )}
                                         </div>
                                     }
-                                    position={"bottom center"}
+                                    position={"bottom left"}
                                     on={"hover"}
                                     arrow={true}
                                 >

--- a/leech/src/modules/dns/errors.rs
+++ b/leech/src/modules/dns/errors.rs
@@ -1,6 +1,11 @@
 //! Holds all the errors from dns resolution
 
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+use itertools::Itertools;
 use thiserror::Error;
+use trust_dns_resolver::error::ResolveError;
 
 /// DNS Resolution error types
 #[derive(Debug, Error)]
@@ -8,4 +13,107 @@ pub enum DnsResolutionError {
     /// Error creating the system resolver
     #[error("Could not create system resolver: {0}")]
     CreateSystemResolver(#[from] trust_dns_resolver::error::ResolveError),
+    /// Failed at least parts of the input
+    #[error("Failed resolving the following domains:\n{}", format_list(.0))]
+    SomeFailed(Vec<ResolutionStatus>),
+}
+
+/// Resolution status for a single domain in a DNS resolution attack.
+#[derive(Debug)]
+pub struct ResolutionStatus {
+    /// The input domain
+    pub domain: String,
+    /// A/AAAA/CNAME lookup status
+    pub ip: LookupResultStatus,
+    /// MX lookup status
+    pub mx: LookupResultStatus,
+    /// TLSA lookup status
+    pub tlsa: LookupResultStatus,
+    /// TXT lookup status
+    pub txt: LookupResultStatus,
+    /// CAA lookup status
+    pub caa: LookupResultStatus,
+}
+
+impl ResolutionStatus {
+    /// Returns true if any field is error
+    pub fn has_error(&self) -> bool {
+        self.ip.is_error()
+            || self.mx.is_error()
+            || self.tlsa.is_error()
+            || self.txt.is_error()
+            || self.caa.is_error()
+    }
+
+    /// Returns true if any field is Success
+    pub fn has_records(&self) -> bool {
+        self.ip.is_success()
+            || self.mx.is_success()
+            || self.tlsa.is_success()
+            || self.txt.is_success()
+            || self.caa.is_success()
+    }
+}
+
+///
+#[derive(Debug)]
+pub enum LookupResultStatus {
+    /// No error and got records
+    Success,
+    /// Got no records
+    NoRecords,
+    /// Got some I/O error or similar
+    Error(ResolveError),
+}
+
+impl Display for LookupResultStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LookupResultStatus::Success => write!(f, "ok"),
+            LookupResultStatus::NoRecords => write!(f, "no records"),
+            LookupResultStatus::Error(e) => write!(f, "FAIL: {e}"),
+        }
+    }
+}
+
+impl LookupResultStatus {
+    fn is_success(&self) -> bool {
+        matches!(self, LookupResultStatus::Success)
+    }
+
+    fn is_error(&self) -> bool {
+        matches!(self, LookupResultStatus::Error(_))
+    }
+}
+
+fn format_list<T>(v: &[T]) -> String
+where
+    T: Display,
+{
+    return v.iter().map(|v| format!("- {}", v)).join("\n");
+}
+
+impl Display for ResolutionStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let ResolutionStatus {
+            domain,
+            ip,
+            mx,
+            tlsa,
+            txt,
+            caa,
+        } = self;
+        if !self.has_error() {
+            if self.has_records() {
+                write!(f, "{domain}: ok")
+            } else {
+                write!(f, "{domain}: no records")
+            }
+        } else {
+            write!(
+                f,
+                "{domain}: IP {ip}, MX {mx}, TLSA {tlsa}, TXT {txt}, CAA {caa}",
+            )
+        }
+    }
 }

--- a/leech/src/modules/dns/mod.rs
+++ b/leech/src/modules/dns/mod.rs
@@ -22,6 +22,8 @@ use trust_dns_resolver::proto::rr::RecordType;
 use trust_dns_resolver::TokioAsyncResolver;
 
 use crate::modules::dns::errors::DnsResolutionError;
+use crate::modules::dns::errors::LookupResultStatus;
+use crate::modules::dns::errors::ResolutionStatus;
 
 /// Result of a subdomain
 #[derive(Debug, Clone)]
@@ -83,10 +85,6 @@ pub enum DnsRecordResult {
 pub struct DnsResolutionSettings {
     /// The domains to resolve
     pub domains: Vec<String>,
-    /// Maximum of concurrent tasks that should be spawned
-    ///
-    /// 0 means, that there should be no limit.
-    pub concurrent_limit: u32,
 }
 
 /// DNS resolution
@@ -103,73 +101,108 @@ pub async fn dns_resolution(
     let resolver = TokioAsyncResolver::tokio_from_system_conf()
         .map_err(DnsResolutionError::CreateSystemResolver)?;
 
-    // TODO: hard limit MAX workers
-    let chunk_count = if settings.concurrent_limit == 0 {
-        settings.domains.len()
-    } else {
-        (settings.domains.len() as f32 / settings.concurrent_limit as f32).ceil() as usize
-    };
-
-    stream::iter(settings.domains)
-        .chunks(chunk_count)
-        .for_each_concurrent(settings.concurrent_limit as usize, move |chunk_domains| {
+    let mut failed = stream::iter(settings.domains)
+        .map(move |domain| {
             let resolver = resolver.clone();
             let tx = tx.clone();
-            async move {
-                for domain in chunk_domains {
-                    debug!("Started dns resolution for {}", domain);
-
-                    // A, AAAA, CNAME
-                    if let Ok(res) = resolve(resolver.lookup_ip(&domain)).await {
-                        send_records(&domain, &tx, res.as_lookup().records()).await;
-                    }
-
-                    if let Ok(res) = resolve(resolver.mx_lookup(&domain)).await {
-                        send_records(&domain, &tx, res.as_lookup().records()).await;
-                    }
-
-                    if let Ok(res) = resolve(resolver.tlsa_lookup(&domain)).await {
-                        send_records(&domain, &tx, res.as_lookup().records()).await;
-                    }
-
-                    if let Ok(res) = resolve(resolver.txt_lookup(&domain)).await {
-                        send_records(&domain, &tx, res.as_lookup().records()).await;
-                    }
-
-                    // TODO: noted as unstable interface
-                    if let Ok(res) = resolver.lookup(&domain, RecordType::CAA).await {
-                        send_records(&domain, &tx, res.records()).await;
-                    }
-
-                    debug!("Finished dns resolution for {}", domain);
-                }
-            }
+            resolve_single(domain.clone(), resolver, tx)
         })
+        .buffer_unordered(8)
+        .collect::<Vec<_>>()
         .await;
+    failed.retain(|v| v.has_error() || !v.has_records());
 
-    info!("Finished DNS resolution");
+    info!(
+        "Finished DNS resolution with {} failed domains",
+        failed.len()
+    );
 
-    Ok(())
+    if !failed.is_empty() {
+        Err(DnsResolutionError::SomeFailed(failed))
+    } else {
+        Ok(())
+    }
 }
 
-async fn resolve<T, Func>(resolver: Func) -> Result<T, ()>
+async fn resolve_single(
+    domain: String,
+    resolver: TokioAsyncResolver,
+    tx: Sender<DnsRecordResult>,
+) -> ResolutionStatus {
+    debug!("Started dns resolution for {}", domain);
+
+    macro_rules! run {
+        ( $resolveFn:expr ) => {
+            match resolve($resolveFn).await {
+                Ok(res) => {
+                    if let Some(res) = res {
+                        send_records(&domain, &tx, res.as_lookup().records()).await;
+                        LookupResultStatus::Success
+                    } else {
+                        LookupResultStatus::NoRecords
+                    }
+                }
+                Err(err) => LookupResultStatus::Error(err),
+            }
+        };
+    }
+
+    macro_rules! run_manual {
+        ( $resolveFn:expr ) => {
+            match resolve($resolveFn).await {
+                Ok(res) => {
+                    if let Some(res) = res {
+                        send_records(&domain, &tx, res.records()).await;
+                        LookupResultStatus::Success
+                    } else {
+                        LookupResultStatus::NoRecords
+                    }
+                }
+                Err(err) => LookupResultStatus::Error(err),
+            }
+        };
+    }
+
+    // A, AAAA, CNAME
+    let res = ResolutionStatus {
+        ip: run!(resolver.lookup_ip(&domain)),
+        mx: run!(resolver.mx_lookup(&domain)),
+        tlsa: run!(resolver.tlsa_lookup(&domain)),
+        txt: run!(resolver.txt_lookup(&domain)),
+        // TODO: noted as unstable interface
+        caa: run_manual!(resolver.lookup(&domain, RecordType::CAA)),
+        domain,
+    };
+    debug!("Finished dns resolution: {res}");
+    res
+}
+
+async fn resolve<T, Func>(resolver: Func) -> Result<Option<T>, ResolveError>
 where
     Func: Future<Output = Result<T, ResolveError>>,
 {
-    return resolver.await.map_err(|err| match err.kind() {
-        ResolveErrorKind::Message(err) => error!("Message: {err}"),
-        ResolveErrorKind::Msg(err) => error!("Msg: {err}"),
-        ResolveErrorKind::NoConnections => {
-            error!("There are no resolvers available")
+    let r = resolver.await;
+    match r {
+        Ok(v) => Ok(Some(v)),
+        Err(err) => {
+            match err.kind() {
+                ResolveErrorKind::Message(err) => error!("Message: {err}"),
+                ResolveErrorKind::Msg(err) => error!("Msg: {err}"),
+                ResolveErrorKind::NoConnections => {
+                    error!("There are no resolvers available")
+                }
+                ResolveErrorKind::Io(err) => error!("IO error: {err}"),
+                ResolveErrorKind::Proto(err) => error!("Proto error {err}"),
+                ResolveErrorKind::Timeout => error!("Timeout while query"),
+                ResolveErrorKind::NoRecordsFound { .. } => {
+                    debug!("Wildcard test: no wildcard");
+                    return Ok(None);
+                }
+                _ => error!("Unknown error"),
+            }
+            Err(err)
         }
-        ResolveErrorKind::Io(err) => error!("IO error: {err}"),
-        ResolveErrorKind::Proto(err) => error!("Proto error {err}"),
-        ResolveErrorKind::Timeout => error!("Timeout while query"),
-        ResolveErrorKind::NoRecordsFound { .. } => {
-            debug!("Wildcard test: no wildcard")
-        }
-        _ => error!("Unknown error"),
-    });
+    }
 }
 
 async fn send_records(domain: &str, tx: &Sender<DnsRecordResult>, records: &[Record]) {

--- a/leech/src/modules/dns/txt.rs
+++ b/leech/src/modules/dns/txt.rs
@@ -278,7 +278,7 @@ fn process_txt_record(record: &[u8]) -> Option<TxtScanInfo> {
 }
 
 async fn domain_impl(resolver: ResolverT, tx: Sender<DnsTxtScanResult>, domain: String) {
-    if let Ok(res) = resolve(resolver.txt_lookup(&domain)).await {
+    if let Ok(Some(res)) = resolve(resolver.txt_lookup(&domain)).await {
         let records = res.as_lookup().records();
         let mut services = Vec::new();
         for record in records {

--- a/leech/src/rpc/attacks.rs
+++ b/leech/src/rpc/attacks.rs
@@ -410,7 +410,7 @@ impl ReqAttackService for Attacks {
 
         let settings = DnsResolutionSettings {
             domains: req.targets,
-            concurrent_limit: req.concurrent_limit,
+            // TODO: concurrent limit currently has no effect
         };
 
         self.stream_attack(


### PR DESCRIPTION
if no records at all are found, shows an error like `DOMAIN: no records` (so that user knows when they typo'd)

if other errors like I/O errors occur during lookup, reports issues like `DOMAIN: IP: error message, MX: error message, ...`