### PR TITLE
Revamp input prefilling

### DIFF
--- a/kraken_frontend/src/styling/workspace-attacks.css
+++ b/kraken_frontend/src/styling/workspace-attacks.css
@@ -1,6 +1,6 @@
 .workspace-attacks-container {
     display: grid;
-    grid-template-columns: 1.5fr 4fr 2fr;
+    grid-template-columns: 50ch 4fr 2fr;
     gap: 1em;
 }
 
@@ -165,7 +165,7 @@
 .workspace-attacks-info > .selection {
     flex-shrink: 1;
     flex-grow: 1;
-    overflow-y: auto;
+    overflow: auto;
     height: 0;
 }
 

--- a/kraken_frontend/src/svg/attacks.tsx
+++ b/kraken_frontend/src/svg/attacks.tsx
@@ -6,7 +6,7 @@ export type AttacksParams = {
     activeAttack: AttackType | null;
     onAttackHover: (attack_type: AttackType | null) => void;
     onAttackSelect: (attack_type: AttackType) => void;
-    disabled: Partial<Record<AttackType, boolean>>;
+    disabled: Record<AttackType, boolean>;
     onClickOutside?: (e: React.MouseEvent<SVGSVGElement>) => any;
 
     className?: string;
@@ -260,7 +260,7 @@ function Hex(props: {
     activeAttack: AttackType | null;
     onAttackHover: (attack_type: AttackType | null) => void;
     onAttackSelect: (attack_type: AttackType) => void;
-    disabled: Partial<Record<AttackType, boolean>>;
+    disabled: Record<AttackType, boolean>;
     onClickOutside?: (e: React.MouseEvent<SVGSVGElement>) => any;
 }) {
     // we use useState so react caches the random value for us.
@@ -271,7 +271,7 @@ function Hex(props: {
 
     const mouseHandler = useCallback(
         (attackType: AttackType) =>
-            props.disabled[attackType] || false
+            props.disabled[attackType]
                 ? {}
                 : {
                       onClick: () => props.onAttackSelect(attackType),

--- a/kraken_frontend/src/views/workspace/attacks/attack-input.tsx
+++ b/kraken_frontend/src/views/workspace/attacks/attack-input.tsx
@@ -10,7 +10,7 @@ import { parseUserPorts } from "../../../utils/ports";
 export interface IAttackInputProps extends Omit<React.HTMLProps<HTMLElement>, "ref"> {
     valueKey: string;
     label: string;
-    prefill: string | undefined;
+    prefill: any[] | undefined;
     value: any;
     required: boolean;
     onUpdate: (key: string, v: any) => any;
@@ -247,8 +247,10 @@ const DEHASHED_SEARCH_TYPES: Array<SelectValue> = [
 ];
 
 export const DehashedAttackInput = forwardRef((props: AttackInputProps<Query>, ref) => {
-    let [search, setSearch] = useState<string>(props.prefill || "");
-    let [type, setType] = useState<null | SelectValue>(null);
+    let [search, setSearch] = useState<string>(props.value !== undefined ? Object.keys(props.value)[0] || "" : "");
+    let [type, setType] = useState<null | SelectValue>(
+        props.value && search ? (props.value as any)[search]?.simple || "" : "",
+    );
 
     let htmlProps: any = { ...props };
     delete htmlProps["value"];


### PR DESCRIPTION
- we can now prefill based on service name
- filter only TCP/UDP ports
- utilize the full raw API types in a custom function

This moved the prefill logic out of generic-attack-form into workspace-attacks.

The preview in workspace-attacks now also shows the actual data that is going to be sent via the API now.

The new architecture is a bit easier to understand than the old one I think.

Weird selection combinations now filter to the valid subset of values. Since we got a preview of full data for the user now, this is better than having them error when trying to submit.

Fixes disabled attacks based on input types, removes the need to hardcode the allowed attacks for which selection types.