### PR TITLE
Swapped the order in which ips and ports are iterated

### DIFF
--- a/leech/src/modules/service_detection/tcp/mod.rs
+++ b/leech/src/modules/service_detection/tcp/mod.rs
@@ -110,9 +110,9 @@ pub async fn start_tcp_service_detection(
         .concurrent_limit
         .try_into()
         .expect("u32 should be convertible to usize");
-    iter_addresses
-        .cartesian_product(iter_ports)
-        .try_for_each_concurrent(Some(limit), |(ip, port)| async move {
+    iter_ports
+        .cartesian_product(iter_addresses)
+        .try_for_each_concurrent(Some(limit), |(port, ip)| async move {
             let socket = SocketAddr::new(ip, port);
             if is_port_open(
                 socket,


### PR DESCRIPTION
Previously they were: `for ip in ips { for port in ports { ... } }` 

This meant that an ip's high ports were scanned before the next ip's low ports were which is unintuitive.

So the new order is: `for port in ports { for ip in ips {...} }` 

This also balances the load over all hosts since the loop body is run concurrently.