### PR TITLE
support CIDR notation in OS detection

### DIFF
--- a/kraken-proto/proto/attacks.proto
+++ b/kraken-proto/proto/attacks.proto
@@ -225,7 +225,7 @@ message DnsResolutionResponse {
 /*
  * DNS TXT scan
  */
- message DnsTxtScanRequest {
+message DnsTxtScanRequest {
   // A unique id that identifier the attack
   string attack_uuid = 1;
   // The domains to resolve
@@ -244,8 +244,8 @@ message DnsTxtScanResponse {
 message OsDetectionRequest {
   // A unique id that identifier the attack
   string attack_uuid = 1;
-  // the host address to scan
-  attacks.shared.Address address = 2;
+  // The ip addresses / networks to scan
+  repeated attacks.shared.NetOrAddress targets = 2;
   // set to skip open port detection and use this port for TCP fingerprinting
   optional uint32 fingerprint_port = 3;
   // set to perform OS detection through SSH header
@@ -260,6 +260,10 @@ message OsDetectionRequest {
   uint64 port_ack_timeout = 8;
   // If fingerprint_port is not set, maximum parallel TCP SYN requests
   uint32 port_parallel_syns = 9;
+  // Maximum of concurrent host scans that should be spawned
+  //
+  // 0 means, that there should be no limit.
+  uint32 concurrent_limit = 10;
 }
 
 // OS detection response
@@ -284,7 +288,7 @@ service ReqAttackService {
   rpc HostsAliveCheck(HostsAliveRequest) returns (stream HostsAliveResponse);
   rpc DnsResolution(DnsResolutionRequest) returns (stream DnsResolutionResponse);
   rpc DnsTxtScan(DnsTxtScanRequest) returns (stream DnsTxtScanResponse);
-  rpc OsDetection(OsDetectionRequest) returns (OsDetectionResponse);
+  rpc OsDetection(OsDetectionRequest) returns (stream OsDetectionResponse);
 }
 
 /*
@@ -316,7 +320,7 @@ message PushAttackRequest {
     // Response streamed by a dns txt scan attack
     RepeatedDnsTxtScanResponse dns_txt_scan = 10;
     // Response to a operating system detection request
-    OsDetectionResponse os_detection = 11;
+    RepeatedOsDetectionResponse os_detection = 11;
   }
 }
 
@@ -349,6 +353,11 @@ message RepeatedUdpServiceDetectionResponse {
 message RepeatedDnsTxtScanResponse {
   // repeated DnsTxtScanResponse
   repeated DnsTxtScanResponse responses = 1;
+}
+// Thin wrapper to have a `repeated OsDetectionResponse` in a `oneof`
+message RepeatedOsDetectionResponse {
+  // repeated OsDetectionResponse
+  repeated OsDetectionResponse responses = 1;
 }
 
 // Response to a manually pushed attack

--- a/kraken/src/api/handler/attacks/handler.rs
+++ b/kraken/src/api/handler/attacks/handler.rs
@@ -180,7 +180,7 @@ pub async fn os_detection(
 ) -> ApiResult<HttpResponse> {
     let OsDetectionRequest {
         leech_uuid,
-        address,
+        targets,
         fingerprint_port,
         ssh_port,
         fingerprint_timeout,
@@ -188,6 +188,7 @@ pub async fn os_detection(
         ssh_timeout,
         port_ack_timeout,
         port_parallel_syns,
+        concurrent_limit,
         workspace_uuid,
     } = req.into_inner();
 
@@ -202,7 +203,7 @@ pub async fn os_detection(
         user_uuid,
         leech,
         OsDetectionParams {
-            target: address,
+            targets,
             fingerprint_port,
             ssh_port,
             fingerprint_timeout,
@@ -210,6 +211,7 @@ pub async fn os_detection(
             ssh_timeout,
             port_ack_timeout,
             port_parallel_syns,
+            concurrent_limit,
         },
     )
     .await?;

--- a/kraken/src/api/handler/attacks/schema.rs
+++ b/kraken/src/api/handler/attacks/schema.rs
@@ -222,9 +222,9 @@ pub struct OsDetectionRequest {
     /// Leave empty to use a random leech
     pub leech_uuid: Option<Uuid>,
 
-    /// The ip address of the host to scan
-    #[schema(value_type = String, example = "10.13.37.1")]
-    pub address: IpAddr,
+    /// The ip addresses / networks or domains to scan
+    #[schema(value_type = Vec<String>, example = json!(["10.13.37.1", "10.13.37.0/24", "google.com"]))]
+    pub targets: Vec<DomainOrNetwork>,
 
     /// set to skip open port detection and use this port for TCP fingerprinting
     pub fingerprint_port: Option<u32>,
@@ -249,6 +249,10 @@ pub struct OsDetectionRequest {
 
     /// The workspace to execute the attack in
     pub workspace_uuid: Uuid,
+
+    /// The concurrent task limit
+    #[schema(example = 5000)]
+    pub concurrent_limit: u32,
 }
 
 /// Request to resolve domains

--- a/kraken/src/modules/attacks/mod.rs
+++ b/kraken/src/modules/attacks/mod.rs
@@ -164,7 +164,7 @@ pub async fn start_host_alive(
 /// The parameters of a "OS detection" attack
 pub struct OsDetectionParams {
     /// The ip addresses / networks to scan
-    pub target: IpAddr,
+    pub targets: Vec<DomainOrNetwork>,
     /// set to skip open port detection and use this port for TCP fingerprinting
     pub fingerprint_port: Option<u32>,
     /// set to perform OS detection through SSH header
@@ -179,6 +179,8 @@ pub struct OsDetectionParams {
     pub port_ack_timeout: u64,
     /// If fingerprint_port is not set, maximum parallel TCP SYN requests
     pub port_parallel_syns: u32,
+    /// The concurrent host scan limit
+    pub concurrent_limit: u32,
 }
 /// Start a "OS detection" attack
 pub async fn start_os_detection(

--- a/kraken/src/rpc/server.rs
+++ b/kraken/src/rpc/server.rs
@@ -138,8 +138,8 @@ impl PushAttackService for Results {
             push_attack_request::Response::UdpServiceDetection(repeated) => {
                 attack.handle_vec_response(repeated.responses).await
             }
-            push_attack_request::Response::OsDetection(response) => {
-                attack.handle_response(response).await
+            push_attack_request::Response::OsDetection(repeated) => {
+                attack.handle_vec_response(repeated.responses).await
             }
         };
 

--- a/kraken_frontend/openapi.json
+++ b/kraken_frontend/openapi.json
@@ -11153,13 +11153,14 @@
                 "type": "object",
                 "description": "OS detection request",
                 "required": [
-                    "address",
+                    "targets",
                     "fingerprint_timeout",
                     "ssh_connect_timeout",
                     "ssh_timeout",
                     "port_ack_timeout",
                     "port_parallel_syns",
-                    "workspace_uuid"
+                    "workspace_uuid",
+                    "concurrent_limit"
                 ],
                 "properties": {
                     "leech_uuid": {
@@ -11168,10 +11169,13 @@
                         "description": "The leech to use\n\nLeave empty to use a random leech",
                         "nullable": true
                     },
-                    "address": {
-                        "type": "string",
-                        "description": "The ip address of the host to scan",
-                        "example": "10.13.37.1"
+                    "targets": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "The ip addresses / networks or domains to scan",
+                        "example": ["10.13.37.1", "10.13.37.0/24", "google.com"]
                     },
                     "fingerprint_port": {
                         "type": "integer",
@@ -11221,6 +11225,13 @@
                         "type": "string",
                         "format": "uuid",
                         "description": "The workspace to execute the attack in"
+                    },
+                    "concurrent_limit": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "The concurrent task limit",
+                        "example": 5000,
+                        "minimum": 0
                     }
                 }
             },

--- a/kraken_frontend/src/api/generated/models/OsDetectionRequest.ts
+++ b/kraken_frontend/src/api/generated/models/OsDetectionRequest.ts
@@ -28,11 +28,11 @@ export interface OsDetectionRequest {
      */
     leechUuid?: string | null;
     /**
-     * The ip address of the host to scan
-     * @type {string}
+     * The ip addresses / networks or domains to scan
+     * @type {Array<string>}
      * @memberof OsDetectionRequest
      */
-    address: string;
+    targets: Array<string>;
     /**
      * set to skip open port detection and use this port for TCP fingerprinting
      * @type {number}
@@ -81,6 +81,12 @@ export interface OsDetectionRequest {
      * @memberof OsDetectionRequest
      */
     workspaceUuid: string;
+    /**
+     * The concurrent task limit
+     * @type {number}
+     * @memberof OsDetectionRequest
+     */
+    concurrentLimit: number;
 }
 
 /**
@@ -88,13 +94,14 @@ export interface OsDetectionRequest {
  */
 export function instanceOfOsDetectionRequest(value: object): boolean {
     let isInstance = true;
-    isInstance = isInstance && "address" in value;
+    isInstance = isInstance && "targets" in value;
     isInstance = isInstance && "fingerprintTimeout" in value;
     isInstance = isInstance && "sshConnectTimeout" in value;
     isInstance = isInstance && "sshTimeout" in value;
     isInstance = isInstance && "portAckTimeout" in value;
     isInstance = isInstance && "portParallelSyns" in value;
     isInstance = isInstance && "workspaceUuid" in value;
+    isInstance = isInstance && "concurrentLimit" in value;
 
     return isInstance;
 }
@@ -110,7 +117,7 @@ export function OsDetectionRequestFromJSONTyped(json: any, ignoreDiscriminator: 
     return {
         
         'leechUuid': !exists(json, 'leech_uuid') ? undefined : json['leech_uuid'],
-        'address': json['address'],
+        'targets': json['targets'],
         'fingerprintPort': !exists(json, 'fingerprint_port') ? undefined : json['fingerprint_port'],
         'sshPort': !exists(json, 'ssh_port') ? undefined : json['ssh_port'],
         'fingerprintTimeout': json['fingerprint_timeout'],
@@ -119,6 +126,7 @@ export function OsDetectionRequestFromJSONTyped(json: any, ignoreDiscriminator: 
         'portAckTimeout': json['port_ack_timeout'],
         'portParallelSyns': json['port_parallel_syns'],
         'workspaceUuid': json['workspace_uuid'],
+        'concurrentLimit': json['concurrent_limit'],
     };
 }
 
@@ -132,7 +140,7 @@ export function OsDetectionRequestToJSON(value?: OsDetectionRequest | null): any
     return {
         
         'leech_uuid': value.leechUuid,
-        'address': value.address,
+        'targets': value.targets,
         'fingerprint_port': value.fingerprintPort,
         'ssh_port': value.sshPort,
         'fingerprint_timeout': value.fingerprintTimeout,
@@ -141,6 +149,7 @@ export function OsDetectionRequestToJSON(value?: OsDetectionRequest | null): any
         'port_ack_timeout': value.portAckTimeout,
         'port_parallel_syns': value.portParallelSyns,
         'workspace_uuid': value.workspaceUuid,
+        'concurrent_limit': value.concurrentLimit,
     };
 }
 

--- a/kraken_frontend/src/views/workspace/workspace-attacks.tsx
+++ b/kraken_frontend/src/views/workspace/workspace-attacks.tsx
@@ -471,12 +471,12 @@ const ATTACKS: AllAttackDescr = {
             endpoint: "osDetection",
             jsonKey: "osDetectionRequest",
             inputs: {
-                address: {
-                    defaultValue: "",
-                    prefill: ["ipAddr"],
-                    label: "IP",
+                targets: {
+                    label: "Domain / IP / net in CIDR",
+                    multi: true,
+                    defaultValue: undefined,
+                    prefill: ["domain", "ipAddr"],
                     type: StringAttackInput,
-                    multi: false,
                     required: true,
                 },
                 sshPort: {
@@ -533,6 +533,14 @@ const ATTACKS: AllAttackDescr = {
                     type: NumberAttackInput,
                     required: true,
                     multi: false,
+                },
+                concurrentLimit: {
+                    label: "Concurrency Limit",
+                    multi: false,
+                    defaultValue: 32,
+                    required: true,
+                    type: NumberAttackInput,
+                    group: "Advanced",
                 },
             },
         },


### PR DESCRIPTION
this is the first attack that only implements streaming with a single async one-shot method inside its module implementation. The streaming conversion is done in attacks.rs using `try_for_each_concurrent` now.

For all the attacks which simply only run a for_each_concurrent without further work in their implementation we might want to convert to this pattern & add some wrapper utility function that automatically can handle this.