### PR TITLE
make SelectableText components more obvious to the user

### DIFF
--- a/kraken_frontend/src/components/selectable-text.tsx
+++ b/kraken_frontend/src/components/selectable-text.tsx
@@ -38,6 +38,7 @@ export default function SelectableText(props: SelectableTextProps) {
     return (
         <As
             {...props}
+            className={`selectable-text ${props.className ?? ""}`}
             ref={elem}
             onMouseDown={(e) => {
                 location.current = [e.clientX, e.clientY];

--- a/kraken_frontend/src/index.css
+++ b/kraken_frontend/src/index.css
@@ -144,3 +144,8 @@ body {
 .popup-content > .pane-thin {
     backdrop-filter: blur(8px);
 }
+
+.selectable-text:hover {
+    /* box shadow instead of outline, since outline may overflow / get clipped by overflow: hidden */
+    box-shadow: 0px 0px 0px 1px var(--primary-op) inset;
+}


### PR DESCRIPTION
shows a faint outline around the text on hover now