### PR TITLE
add OpenVPN probe

### DIFF
--- a/leech/src/modules/service_detection/probe_files/tcp/openvpn.probe
+++ b/leech/src/modules/service_detection/probe_files/tcp/openvpn.probe
@@ -1,0 +1,6 @@
+service: openvpn
+prevalence: often
+probes:
+  - tcp: yes
+    payload_hex: 000e38dc1d462c8771a7c00000000000
+    regex: ^\x00\x1a@(?-u:.{8})\x01\x00\x00\x00\x00\xdc\x1d\x46\x2c\x87\x71\xa7\xc0

--- a/leech/src/modules/service_detection/probe_files/udp/openvpn.probe
+++ b/leech/src/modules/service_detection/probe_files/udp/openvpn.probe
@@ -1,0 +1,6 @@
+service: openvpn
+prevalence: often
+probes:
+  - udp: yes
+    payload_hex: 38dc1d462c8771a7c00000000000
+    regex: ^@(?-u:.{8})\x01\x00\x00\x00\x00\xdc\x1d\x46\x2c\x87\x71\xa7\xc0


### PR DESCRIPTION
cannot detect OpenVPN if `tls-auth` is configured (enables an "HMAC firewall" with a pre-shared secret that otherwise rejects responding to packets if not signed correctly)

Send a P_CONTROL_HARD_RESET_CLIENT_V2 request with a hardcoded session ID and expects a P_CONTROL_HARD_RESET_SERVER_V2 response to mark this as openvpn server