### PR TITLE
Fixed weird linker error arround parking_lot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,6 +2393,7 @@ dependencies = [
  "ipnetwork",
  "kraken-proto",
  "log",
+ "parking_lot",
  "prost",
  "prost-types",
  "rand",
@@ -3068,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",

--- a/kraken/Cargo.toml
+++ b/kraken/Cargo.toml
@@ -29,6 +29,9 @@ name = "kraken"
 
 kraken-proto = { path = "../kraken-proto", optional = true }
 
+# Very common sub-dependency which is included to pin its version
+parking_lot = "=0.12.2"
+
 # Webframework
 actix-web = { version = "~4", optional = true }
 # Extensions for actix-web


### PR DESCRIPTION
The last dependency update caused my build inside the vagrant container to fail with a linker error.
(Yes I have tried a clean container)
I'm not sure, if this problem just affects me, but this commit fixed it on my machine.

I have looked at `parking_lot`'s commits but the only thing they changed is, they added a new re-export.