### PR TITLE
Fix editor cache

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## WIP
 
+### Backend fixes
+
+- Fixed details for finding affecteds not being stored correctly
+
 ## v0.4
 
 ### Frontend

--- a/kraken/src/api/handler/data_export/handler.rs
+++ b/kraken/src/api/handler/data_export/handler.rs
@@ -306,7 +306,7 @@ pub(crate) async fn export_workspace(
         .try_fold(
             HashMap::<Uuid, HashMap<Uuid, AggregatedFindingAffected>>::new(),
             |mut map, (finding, aggr_uuid, aggr_type)| async move {
-                let (details, _) = GLOBAL.editor_cache.finding_affected_export_details.get(aggr_uuid).await?.unwrap_or_default();
+                let (details, _) = GLOBAL.editor_cache.finding_affected_export_details.get((finding,aggr_uuid)).await?.unwrap_or_default();
                 map.entry(finding).or_default().insert(aggr_uuid, AggregatedFindingAffected {
                     uuid: aggr_uuid,
                     r#type: aggr_type,

--- a/kraken/src/api/handler/data_export/handler.rs
+++ b/kraken/src/api/handler/data_export/handler.rs
@@ -51,7 +51,6 @@ use crate::models::Service;
 use crate::models::ServiceGlobalTag;
 use crate::models::ServiceWorkspaceTag;
 use crate::models::WorkspaceAccessToken;
-use crate::modules::cache::EditorCached;
 
 #[utoipa::path(
     tag = "Data Export",

--- a/kraken/src/api/handler/finding_affected/handler.rs
+++ b/kraken/src/api/handler/finding_affected/handler.rs
@@ -471,9 +471,9 @@ pub async fn get_finding_affected(
         affected,
         affected_tags,
         #[rustfmt::skip]
-        export_details: GLOBAL.editor_cache.finding_affected_export_details.get(a_uuid).await?.unwrap_or_default().0,
+        export_details: GLOBAL.editor_cache.finding_affected_export_details.get((f_uuid, a_uuid)).await?.unwrap_or_default().0,
         #[rustfmt::skip]
-        user_details: GLOBAL.editor_cache.finding_affected_user_details.get(a_uuid).await?.unwrap_or_default().0,
+        user_details: GLOBAL.editor_cache.finding_affected_user_details.get((f_uuid, a_uuid)).await?.unwrap_or_default().0,
         tool_details: details.as_mut().and_then(|d| d.tool_details.take()),
         screenshot: details
             .as_mut()
@@ -605,11 +605,11 @@ pub async fn delete_finding_affected(
     GLOBAL
         .editor_cache
         .finding_affected_export_details
-        .delete(a_uuid);
+        .delete((f_uuid, a_uuid));
     GLOBAL
         .editor_cache
         .finding_affected_user_details
-        .delete(a_uuid);
+        .delete((f_uuid, a_uuid));
 
     tx.commit().await?;
     GLOBAL

--- a/kraken/src/api/handler/finding_affected/handler.rs
+++ b/kraken/src/api/handler/finding_affected/handler.rs
@@ -56,7 +56,6 @@ use crate::models::ServiceGlobalTag;
 use crate::models::ServiceWorkspaceTag;
 use crate::models::Workspace;
 use crate::models::WorkspaceTag;
-use crate::modules::cache::EditorCached;
 
 /// Add a new affected object to a finding
 #[utoipa::path(

--- a/kraken/src/api/handler/finding_definitions/handler.rs
+++ b/kraken/src/api/handler/finding_definitions/handler.rs
@@ -34,7 +34,6 @@ use crate::models::FindingCategory;
 use crate::models::FindingDefinition;
 use crate::models::FindingDefinitionCategoryRelation;
 use crate::models::InsertFindingDefinition;
-use crate::modules::cache::EditorCached;
 
 /// Add a definition for a finding
 ///

--- a/kraken/src/api/handler/finding_definitions/handler_admin.rs
+++ b/kraken/src/api/handler/finding_definitions/handler_admin.rs
@@ -24,7 +24,6 @@ use crate::models::convert::FromDb;
 use crate::models::Finding;
 use crate::models::FindingAffected;
 use crate::models::FindingDefinition;
-use crate::modules::cache::EditorCached;
 
 /// Get all findings using the finding definition
 #[utoipa::path(

--- a/kraken/src/api/handler/findings/handler.rs
+++ b/kraken/src/api/handler/findings/handler.rs
@@ -40,7 +40,6 @@ use crate::models::FindingDefinitionCategoryRelation;
 use crate::models::FindingDetails;
 use crate::models::FindingFindingCategoryRelation;
 use crate::models::Workspace;
-use crate::modules::cache::EditorCached;
 
 /// Creates a new finding
 #[utoipa::path(

--- a/kraken/src/api/handler/workspaces/handler.rs
+++ b/kraken/src/api/handler/workspaces/handler.rs
@@ -88,7 +88,6 @@ use crate::models::UdpServiceDetectionResult;
 use crate::models::Workspace;
 use crate::models::WorkspaceInvitation;
 use crate::models::WorkspaceMember;
-use crate::modules::cache::EditorCached;
 
 /// Create a new workspace
 #[utoipa::path(

--- a/kraken/src/api/handler/workspaces/utils.rs
+++ b/kraken/src/api/handler/workspaces/utils.rs
@@ -29,7 +29,6 @@ use crate::models::SearchResult;
 use crate::models::User;
 use crate::models::Workspace;
 use crate::models::WorkspaceMember;
-use crate::modules::cache::EditorCached;
 
 pub(crate) fn build_query_list() -> Vec<(String, ModelType)> {
     let table_names_no_ref_to_ws = vec![

--- a/kraken/src/chan/global.rs
+++ b/kraken/src/chan/global.rs
@@ -12,7 +12,7 @@ use crate::chan::leech_manager::LeechManager;
 use crate::chan::settings_manager::SettingsManagerChan;
 use crate::chan::ws_manager::chan::WsManagerChan;
 use crate::modules::aggregator::Aggregator;
-use crate::modules::cache::EditorCache;
+use crate::modules::cache::EditorCaches;
 use crate::modules::cache::UserCache;
 use crate::modules::cache::WorkspaceUsersCache;
 use crate::modules::editor::EditorSync;
@@ -51,7 +51,7 @@ pub struct GlobalChan {
     pub user_cache: UserCache,
 
     /// All caches for editors
-    pub editor_cache: EditorCache,
+    pub editor_cache: EditorCaches,
 
     /// Scheduler for inserting or updating any aggregation model in the database
     pub aggregator: Aggregator,

--- a/kraken/src/main.rs
+++ b/kraken/src/main.rs
@@ -39,7 +39,7 @@ use kraken::config::VAR_DIR;
 use kraken::models::User;
 use kraken::models::UserPermission;
 use kraken::modules::aggregator::Aggregator;
-use kraken::modules::cache::EditorCache;
+use kraken::modules::cache::EditorCaches;
 use kraken::modules::cache::UserCache;
 use kraken::modules::cache::WorkspaceUsersCache;
 use kraken::modules::editor::EditorSync;
@@ -134,7 +134,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let workspace_users_cache = WorkspaceUsersCache::default();
             let user_cache = UserCache::default();
-            let editor_cache = EditorCache::default();
+            let editor_cache = EditorCaches::default();
 
             let aggregator = Aggregator::default();
 

--- a/kraken/src/modules/cache/mod.rs
+++ b/kraken/src/modules/cache/mod.rs
@@ -1,7 +1,6 @@
 //! This module holds all caches of kraken
 
-pub use editor::EditorCache;
-pub use editor::EditorCached;
+pub use editor::EditorCaches;
 pub use user::*;
 pub use workspace_users::*;
 

--- a/kraken/src/modules/editor/mod.rs
+++ b/kraken/src/modules/editor/mod.rs
@@ -26,7 +26,6 @@ use crate::chan::ws_manager::schema::FindingDetails;
 use crate::chan::ws_manager::schema::FindingSection;
 use crate::chan::ws_manager::schema::WsMessage;
 use crate::models::FindingDefinition;
-use crate::modules::cache::EditorCached;
 
 /// Sync editor
 #[derive(Clone)]

--- a/kraken/src/modules/editor/mod.rs
+++ b/kraken/src/modules/editor/mod.rs
@@ -138,14 +138,14 @@ impl EditorSync {
                     GLOBAL
                         .editor_cache
                         .finding_affected_export_details
-                        .get(affected)
+                        .get((finding, affected))
                         .await
                 }
                 FindingDetails::User => {
                     GLOBAL
                         .editor_cache
                         .finding_affected_user_details
-                        .get(affected)
+                        .get((finding, affected))
                         .await
                 }
             };
@@ -200,14 +200,14 @@ impl EditorSync {
                     GLOBAL
                         .editor_cache
                         .finding_affected_export_details
-                        .update(affected, apply_change(&existing, &change))
+                        .update((finding, affected), apply_change(&existing, &change))
                         .await
                 }
                 FindingDetails::User => {
                     GLOBAL
                         .editor_cache
                         .finding_affected_user_details
-                        .update(affected, apply_change(&existing, &change))
+                        .update((finding, affected), apply_change(&existing, &change))
                         .await
                 }
             };
@@ -246,14 +246,14 @@ impl EditorSync {
                 GLOBAL
                     .editor_cache
                     .finding_affected_export_details
-                    .get(affected)
+                    .get((finding, affected))
                     .await
             }
             FindingDetails::User => {
                 GLOBAL
                     .editor_cache
                     .finding_affected_user_details
-                    .get(affected)
+                    .get((finding, affected))
                     .await
             }
         };


### PR DESCRIPTION
Fixed the reported issue of finding affected details being only associated with the affected and not the finding.

In order to fix this issue the editor cache had to be changed fundamentally because its assumption *every item is uniquely identified by one uuid* didn't hold anymore.

Also I fixed the unreported issue of all caches writing their data in case of db failure to `/var/lib/kraken/ws_notes/`.
Now there is a `/var/lib/kraken/editor_cache_failures/` and each cache has its own self explanatory file name scheme.