### PR TITLE
remove height:0 from workspace-table

### DIFF
--- a/kraken_frontend/src/styling/workspace-table.css
+++ b/kraken_frontend/src/styling/workspace-table.css
@@ -40,7 +40,6 @@
     overflow-x: hidden;
     overflow-y: auto;
     flex-grow: 1;
-    height: 0;
     padding: 0 1.5em;
 }
 


### PR DESCRIPTION
fixes "add as affected"

not extensively tested how this affects other things, but regular common functionality still seems to work fine.