### PR TITLE
Create monaco models for empty details lazily

### DIFF
--- a/kraken_frontend/src/views/workspace/components/editor-popup.tsx
+++ b/kraken_frontend/src/views/workspace/components/editor-popup.tsx
@@ -33,6 +33,9 @@ export type EditorPopupProps = {
 
     /** Optional sub heading for the popup providing some more detail */
     subHeading?: React.ReactNode;
+
+    /** Callback when the popup is opened */
+    onOpen?: () => void;
 } & (
     | {
           /** Callback invoked by the editor to change its value */
@@ -53,10 +56,10 @@ export type EditorPopupProps = {
 
 /** A [`<Popup />`]{@link EditorPopup} which opens an editor */
 export default function EditorPopup(props: EditorPopupProps) {
-    const { trigger, value, preview, heading, subHeading } = props;
+    const { trigger, value, preview, heading, subHeading, onOpen } = props;
 
     return (
-        <Popup className="editor-popup" trigger={trigger} nested modal on={"click"}>
+        <Popup className="editor-popup" trigger={trigger} nested modal on={"click"} onOpen={onOpen}>
             <div className="pane">
                 <div className="label">
                     <h1 className="sub-heading">{heading}</h1>

--- a/kraken_frontend/src/views/workspace/workspace-finding/workspace-edit-finding.tsx
+++ b/kraken_frontend/src/views/workspace/workspace-finding/workspace-edit-finding.tsx
@@ -202,8 +202,8 @@ export default function WorkspaceEditFinding(props: WorkspaceEditFindingProps) {
                 )
                     .then((affected) =>
                         affected.map(([uuid, { userDetails, exportDetails, ...fullAffected }]) => {
-                            addAffectedModel(uuid, "User", userDetails);
-                            addAffectedModel(uuid, "Export", exportDetails);
+                            if (userDetails.length > 0) addAffectedModel(uuid, "User", userDetails);
+                            if (exportDetails.length > 0) addAffectedModel(uuid, "Export", exportDetails);
                             return [uuid, fullAffected];
                         }),
                     )
@@ -273,8 +273,8 @@ export default function WorkspaceEditFinding(props: WorkspaceEditFindingProps) {
                             ...affected,
                             [affectedUuid]: newAffected,
                         }));
-                        addAffectedModel(affectedUuid, "User", userDetails);
-                        addAffectedModel(affectedUuid, "Export", exportDetails);
+                        if (userDetails.length > 0) addAffectedModel(affectedUuid, "User", userDetails);
+                        if (exportDetails.length > 0) addAffectedModel(affectedUuid, "Export", exportDetails);
                     }),
                 );
             }),
@@ -293,6 +293,24 @@ export default function WorkspaceEditFinding(props: WorkspaceEditFindingProps) {
                 setAffected(({ [affectedUuid]: _, ...rest }) => rest);
                 affectedModels.removeModel(`${affectedUuid}-user`);
                 affectedModels.removeModel(`${affectedUuid}-export`);
+            }),
+            WS.addEventListener("message.EditorChangedContent", ({ target }) => {
+                if (!("findingAffected" in target)) return;
+                if (target.findingAffected.finding !== finding) return;
+                const affectedUuid = target.findingAffected.affected;
+                if (affectedModels.models[`${affectedUuid}-${target.findingAffected.findingDetails.toLowerCase()}`])
+                    return;
+
+                Api.workspaces.findings.getAffected(workspace, finding, affectedUuid).then(
+                    handleApiError(({ userDetails, exportDetails, ...newAffected }) => {
+                        setAffected((affected) => ({
+                            ...affected,
+                            [affectedUuid]: newAffected,
+                        }));
+                        addAffectedModel(affectedUuid, "User", userDetails);
+                        addAffectedModel(affectedUuid, "Export", exportDetails);
+                    }),
+                );
             }),
         ];
         return () => {
@@ -532,35 +550,45 @@ export default function WorkspaceEditFinding(props: WorkspaceEditFindingProps) {
                                                 <EditorPopup
                                                     trigger={
                                                         <div className="details">
-                                                            {affectedModels.models[`${affectedUuid}-user`].value
-                                                                .length > 0
+                                                            {affectedModels.models[`${affectedUuid}-user`]?.value
+                                                                ?.length > 0
                                                                 ? ["Edit User Details", <EditIcon />]
                                                                 : ["Add User Details", <PlusIcon />]}
                                                         </div>
                                                     }
-                                                    value={affectedModels.models[`${affectedUuid}-user`].value}
+                                                    onOpen={() => {
+                                                        if (!affectedModels.models[`${affectedUuid}-user`]) {
+                                                            addAffectedModel(affectedUuid, "User", "");
+                                                        }
+                                                    }}
+                                                    value={affectedModels.models[`${affectedUuid}-user`]?.value}
                                                     heading={"User Details"}
                                                     subHeading={
                                                         <AffectedLabel affected={fullAffected.affected} pretty />
                                                     }
-                                                    model={affectedModels.models[`${affectedUuid}-user`].model}
+                                                    model={affectedModels.models[`${affectedUuid}-user`]?.model}
                                                 />
                                                 <EditorPopup
                                                     trigger={
                                                         <div className="details">
-                                                            {affectedModels.models[`${affectedUuid}-export`].value
-                                                                .length > 0
+                                                            {affectedModels.models[`${affectedUuid}-export`]?.value
+                                                                ?.length > 0
                                                                 ? ["Edit Export Details", <EditIcon />]
                                                                 : ["Add Export Details", <PlusIcon />]}
                                                         </div>
                                                     }
-                                                    value={affectedModels.models[`${affectedUuid}-export`].value}
+                                                    onOpen={() => {
+                                                        if (!affectedModels.models[`${affectedUuid}-export`]) {
+                                                            addAffectedModel(affectedUuid, "Export", "");
+                                                        }
+                                                    }}
+                                                    value={affectedModels.models[`${affectedUuid}-export`]?.value}
                                                     preview={null}
                                                     heading={"Export Details"}
                                                     subHeading={
                                                         <AffectedLabel affected={fullAffected.affected} pretty />
                                                     }
-                                                    model={affectedModels.models[`${affectedUuid}-export`].model}
+                                                    model={affectedModels.models[`${affectedUuid}-export`]?.model}
                                                 />
                                                 <TagList
                                                     tags={fullAffected.affectedTags}

--- a/kraken_frontend/src/views/workspace/workspace-finding/workspace-edit-finding.tsx
+++ b/kraken_frontend/src/views/workspace/workspace-finding/workspace-edit-finding.tsx
@@ -108,6 +108,21 @@ export default function WorkspaceEditFinding(props: WorkspaceEditFindingProps) {
     >({});
     const affectedModels = useModelStore();
 
+    /** Small wrapper around `affectedModels.addModel` prefilling most parameters */
+    const addAffectedModel = (uuid: string, type: "Export" | "User", value: string) => {
+        affectedModels.addModel(`${uuid}-${type.toLowerCase()}`, {
+            value,
+            language: "markdown",
+            syncTarget: {
+                findingAffected: {
+                    finding: finding,
+                    affected: uuid,
+                    findingDetails: type,
+                },
+            },
+        });
+    };
+
     const dataTableRef = React.useRef<WorkspaceFindingDataTableRef>(null);
     const graphRef = React.useRef<EditingTreeGraphRef>(null);
 
@@ -187,28 +202,8 @@ export default function WorkspaceEditFinding(props: WorkspaceEditFindingProps) {
                 )
                     .then((affected) =>
                         affected.map(([uuid, { userDetails, exportDetails, ...fullAffected }]) => {
-                            affectedModels.addModel(`${uuid}-user`, {
-                                value: userDetails,
-                                language: "markdown",
-                                syncTarget: {
-                                    findingAffected: {
-                                        finding: finding,
-                                        affected: uuid,
-                                        findingDetails: "User",
-                                    },
-                                },
-                            });
-                            affectedModels.addModel(`${uuid}-export`, {
-                                value: exportDetails,
-                                language: "text",
-                                syncTarget: {
-                                    findingAffected: {
-                                        finding: finding,
-                                        affected: uuid,
-                                        findingDetails: "Export",
-                                    },
-                                },
-                            });
+                            addAffectedModel(uuid, "User", userDetails);
+                            addAffectedModel(uuid, "Export", exportDetails);
                             return [uuid, fullAffected];
                         }),
                     )
@@ -278,20 +273,8 @@ export default function WorkspaceEditFinding(props: WorkspaceEditFindingProps) {
                             ...affected,
                             [affectedUuid]: newAffected,
                         }));
-                        affectedModels.addModel(`${affectedUuid}-user`, {
-                            value: userDetails,
-                            language: "markdown",
-                            syncTarget: {
-                                findingAffected: { finding, affected: affectedUuid, findingDetails: "User" },
-                            },
-                        });
-                        affectedModels.addModel(`${affectedUuid}-export`, {
-                            value: exportDetails,
-                            language: "text",
-                            syncTarget: {
-                                findingAffected: { finding, affected: affectedUuid, findingDetails: "Export" },
-                            },
-                        });
+                        addAffectedModel(affectedUuid, "User", userDetails);
+                        addAffectedModel(affectedUuid, "Export", exportDetails);
                     }),
                 );
             }),


### PR DESCRIPTION
Monaco complains when we create ~>100 models.
When editing a finding, we currently create 2 models per affected.
This PR only creates models whose content is not empty